### PR TITLE
add: Advanced menu with all possible settings + relevant settings loading + confirmation prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 ./ryzenadj
+.vscode/
+.vs/
+bin/
+obj/

--- a/RyzenAdjUI_WPF/MainWindow.xaml
+++ b/RyzenAdjUI_WPF/MainWindow.xaml
@@ -48,5 +48,27 @@
         <Button Content="Exit" HorizontalAlignment="Left" Margin="701,9,0,0" VerticalAlignment="Top" Width="75" BorderBrush="#00707070" Background="#00DDDDDD" Foreground="White" FontFamily="AMDRTG" Click="Exit_Click"/>
         <Ellipse x:Name="rcheckBox6" HorizontalAlignment="Left" Height="15" Margin="749,297,0,0" VerticalAlignment="Top" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox6_MouseDown" Fill="#FF1B2329"/>
         <Label Content="Apply settings upon boot" HorizontalAlignment="Left" Margin="607,291,0,0" VerticalAlignment="Top" Foreground="White"/>
+        <Label Content="Advanced Settings" HorizontalAlignment="Left" Margin="20,294,0,0" VerticalAlignment="Top" Foreground="White"/>
+        <Ellipse x:Name="rcheckBox7" HorizontalAlignment="Left" Height="15" Margin="129,302,0,0" VerticalAlignment="Top" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox7_MouseDown" Fill="#FF1B2329"/>
+        <Label Content="PPT Slow Constant Time (ms)" HorizontalAlignment="Left" Margin="20,325,0,-27.4" VerticalAlignment="Top" Foreground="White"/>
+        <Ellipse x:Name="rcheckBox8" HorizontalAlignment="Left" Margin="183,330,0,-27.4" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox8_MouseDown" Fill="#FF1B2329" Height="15" VerticalAlignment="Top"/>
+        <Label Content="VRM SoC Current Limit (mA)" HorizontalAlignment="Left" Margin="20,355,0,-59.4" VerticalAlignment="Top" Foreground="White" Height="26"/>
+        <Ellipse x:Name="rcheckBox9" HorizontalAlignment="Left" Margin="183,360,0,-52.4" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox9_MouseDown" Fill="#FF1B2329" Height="15" VerticalAlignment="Top"/>
+        <Label Content="VRM Current Limit (mA)" HorizontalAlignment="Left" Margin="20,385,0,-87.4" VerticalAlignment="Top" Foreground="White" Height="24"/>
+        <Ellipse x:Name="rcheckBox10" HorizontalAlignment="Left" Margin="183,390,0,-85.4" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox10_MouseDown" Fill="#FF1B2329" Height="15" VerticalAlignment="Top"/>
+        <Label Content="VRM SoC Max Current (mA)" HorizontalAlignment="Left" Margin="20,417,0,-118.4" VerticalAlignment="Top" Foreground="White" Height="23"/>
+        <Ellipse x:Name="rcheckBox11" HorizontalAlignment="Left" Margin="183,420,0,-114.4" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox11_MouseDown" Fill="#FF1B2329" Height="15" VerticalAlignment="Top"/>
+        <Label Content="PSI0 Current Limit (mA)" HorizontalAlignment="Left" Margin="20,445,0,-148.4" VerticalAlignment="Top" Foreground="White" Height="25"/>
+        <Ellipse x:Name="rcheckBox12" HorizontalAlignment="Left" Margin="183,450,0,-143.4" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox12_MouseDown" Fill="#FF1B2329" Height="15" VerticalAlignment="Top"/>
+        <Label Content="PSI0 Soc Current Limit (mA)" HorizontalAlignment="Left" Margin="20,475,0,-183.4" VerticalAlignment="Top" Foreground="White" Height="30"/>
+        <Ellipse x:Name="rcheckBox13" HorizontalAlignment="Left" Margin="183,480,0,-172.4" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox13_MouseDown" Fill="#FF1B2329" Height="15" VerticalAlignment="Top"/>
+        <Label Content="max" HorizontalAlignment="Left" Margin="92,241,0,0" VerticalAlignment="Top" Foreground="White" Width="33"/>
+        <TextBox x:Name="rtextbox8" HorizontalAlignment="Left" Height="23" Margin="215,329,0,-30.4" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="120" Visibility="Hidden"/>
+        <TextBox x:Name="rtextbox9" HorizontalAlignment="Left" Height="23" Margin="215,358,0,-59.4" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="120" Visibility="Hidden"/>
+        <TextBox x:Name="rtextbox10" HorizontalAlignment="Left" Height="23" Margin="215,386,0,-87.4" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="120" Visibility="Hidden"/>
+        <TextBox x:Name="rtextbox11" HorizontalAlignment="Left" Height="23" Margin="215,416,0,-117.4" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="120" Visibility="Hidden"/>
+        <TextBox x:Name="rtextbox12" HorizontalAlignment="Left" Height="23" Margin="215,445,0,-146.4" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="120" Visibility="Hidden"/>
+        <TextBox x:Name="rtextbox13" HorizontalAlignment="Left" Height="23" Margin="215,474,0,-175.4" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Width="120" Visibility="Hidden"/>
+        <Label Content="WARNING: You have enabled advanced settings!&#xD;&#xA;These settings do not need to be modified under normal circumstances.&#xD;&#xA;Only override these values if you know what you are doing!" HorizontalAlignment="Left" Margin="364,386,0,-188.4" VerticalAlignment="Top" Foreground="White" Height="124" Width="419"/>
     </Grid>
 </Window>

--- a/RyzenAdjUI_WPF/MainWindow.xaml
+++ b/RyzenAdjUI_WPF/MainWindow.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Title="MainWindow" Height="323.4" Width="787.333" Background="#72262F49" AllowsTransparency="True" WindowStyle="None" BorderThickness="1" WindowStartupLocation="CenterScreen" BorderBrush="#FF0E0D4E" Topmost="True" MouseLeftButtonDown="Window_MouseDown" Loaded="Window_Loaded">
     <Grid>
-        <Label Content="ryzen mobile adjustment tool" HorizontalAlignment="Left" Margin="15,2,0,0" VerticalAlignment="Top" FontFamily="AMDRTG" FontSize="16" Width="413" Foreground="White"/>
+        <Label Content="Ryzen Mobile Adjustment Tool" HorizontalAlignment="Left" Margin="15,2,0,0" VerticalAlignment="Top" FontFamily="AMDRTG" FontSize="16" Width="413" Foreground="White"/>
         <Rectangle Fill="#FF1B2329" HorizontalAlignment="Left" Height="40" Margin="15,50,0,0" VerticalAlignment="Top" Width="150" Opacity="0.7"/>
         <Label Content="STAPM Limit (W)" HorizontalAlignment="Left" Margin="20,55,0,0" VerticalAlignment="Top" Foreground="White"/>
         <Ellipse x:Name="rcheckBox1" HorizontalAlignment="Left" Height="15" Margin="130,61,0,0" VerticalAlignment="Top" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox1_MouseDown" Fill="#FF1B2329"/>
@@ -44,8 +44,8 @@
         <Label x:Name="lab4" Content="{Binding Value, ElementName=slider4, StringFormat=\{0:0\}}" HorizontalAlignment="Left" Margin="180,205,0,0" VerticalAlignment="Top" Foreground="White" Visibility="Hidden"/>
         <Slider x:Name="slider5" HorizontalAlignment="Left" Margin="228,259,0,0" VerticalAlignment="Top" Width="525" Maximum="100000" Minimum="20000" IsSnapToTickEnabled="True" TickFrequency="5000" Visibility="Hidden"/>
         <Label x:Name="lab5" Content="{Binding Value, ElementName=slider5}" HorizontalAlignment="Left" Margin="168,255,0,0" VerticalAlignment="Top" Foreground="White" Cursor="None" ContentStringFormat="{}{0:D2}" Visibility="Hidden"/>
-        <Button Content="apply" HorizontalAlignment="Left" Margin="690,10,0,0" VerticalAlignment="Top" Width="75" BorderBrush="#00707070" Background="#00DDDDDD" Foreground="White" FontFamily="AMDRTG" Click="Button_Click"/>
+        <Button Content="Apply" HorizontalAlignment="Left" Margin="690,10,0,0" VerticalAlignment="Top" Width="75" BorderBrush="#00707070" Background="#00DDDDDD" Foreground="White" FontFamily="AMDRTG" Click="Button_Click"/>
         <Ellipse x:Name="rcheckBox6" HorizontalAlignment="Left" Height="15" Margin="749,297,0,0" VerticalAlignment="Top" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox6_MouseDown" Fill="#FF1B2329"/>
-        <Label Content="Autostart with Windows" HorizontalAlignment="Left" Margin="607,291,0,0" VerticalAlignment="Top" Foreground="White"/>
+        <Label Content="Apply settings upon boot" HorizontalAlignment="Left" Margin="607,291,0,0" VerticalAlignment="Top" Foreground="White"/>
     </Grid>
 </Window>

--- a/RyzenAdjUI_WPF/MainWindow.xaml
+++ b/RyzenAdjUI_WPF/MainWindow.xaml
@@ -44,7 +44,8 @@
         <Label x:Name="lab4" Content="{Binding Value, ElementName=slider4, StringFormat=\{0:0\}}" HorizontalAlignment="Left" Margin="180,205,0,0" VerticalAlignment="Top" Foreground="White" Visibility="Hidden"/>
         <Slider x:Name="slider5" HorizontalAlignment="Left" Margin="228,259,0,0" VerticalAlignment="Top" Width="525" Maximum="100000" Minimum="20000" IsSnapToTickEnabled="True" TickFrequency="5000" Visibility="Hidden"/>
         <Label x:Name="lab5" Content="{Binding Value, ElementName=slider5}" HorizontalAlignment="Left" Margin="168,255,0,0" VerticalAlignment="Top" Foreground="White" Cursor="None" ContentStringFormat="{}{0:D2}" Visibility="Hidden"/>
-        <Button Content="Apply" HorizontalAlignment="Left" Margin="690,10,0,0" VerticalAlignment="Top" Width="75" BorderBrush="#00707070" Background="#00DDDDDD" Foreground="White" FontFamily="AMDRTG" Click="Button_Click"/>
+        <Button Content="Apply" HorizontalAlignment="Left" Margin="640,9,0,0" VerticalAlignment="Top" Width="75" BorderBrush="#00707070" Background="#00DDDDDD" Foreground="White" FontFamily="AMDRTG" Click="Apply_Click"/>
+        <Button Content="Exit" HorizontalAlignment="Left" Margin="701,9,0,0" VerticalAlignment="Top" Width="75" BorderBrush="#00707070" Background="#00DDDDDD" Foreground="White" FontFamily="AMDRTG" Click="Exit_Click"/>
         <Ellipse x:Name="rcheckBox6" HorizontalAlignment="Left" Height="15" Margin="749,297,0,0" VerticalAlignment="Top" Width="15" Stroke="White" RenderTransformOrigin="0.5,0.5" MouseDown="RcheckBox6_MouseDown" Fill="#FF1B2329"/>
         <Label Content="Apply settings upon boot" HorizontalAlignment="Left" Margin="607,291,0,0" VerticalAlignment="Top" Foreground="White"/>
     </Grid>

--- a/RyzenAdjUI_WPF/MainWindow.xaml.cs
+++ b/RyzenAdjUI_WPF/MainWindow.xaml.cs
@@ -304,7 +304,7 @@ namespace RyzenAdjUI_WPF {
                         {
                             case "stapm-limit":
                                 rcheckBox1.Fill = Brushes.Green;
-                                slider1.Value = double.Parse(typeValue);
+                                slider1.Value = double.Parse(typeValue.Substring(0, typeValue.Length - 4));
                                 cube1.Visibility = Visibility.Visible;
                                 rect1s.Visibility = Visibility.Visible;
                                 slider1.Visibility = Visibility.Visible;
@@ -312,7 +312,7 @@ namespace RyzenAdjUI_WPF {
                                 break;
                             case "fast-limit":
                                 rcheckBox2.Fill = Brushes.Green;
-                                slider2.Value = double.Parse(typeValue);
+                                slider2.Value = double.Parse(typeValue.Substring(0, typeValue.Length - 4));
                                 cube2.Visibility = Visibility.Visible;
                                 rect2s.Visibility = Visibility.Visible;
                                 slider2.Visibility = Visibility.Visible;
@@ -320,7 +320,7 @@ namespace RyzenAdjUI_WPF {
                                 break;
                             case "slow-limit":
                                 rcheckBox3.Fill = Brushes.Green;
-                                slider3.Value = double.Parse(typeValue);
+                                slider3.Value = double.Parse(typeValue.Substring(0, typeValue.Length - 4));
                                 cube3.Visibility = Visibility.Visible;
                                 rect3s.Visibility = Visibility.Visible;
                                 slider3.Visibility = Visibility.Visible;

--- a/RyzenAdjUI_WPF/MainWindow.xaml.cs
+++ b/RyzenAdjUI_WPF/MainWindow.xaml.cs
@@ -171,13 +171,18 @@ namespace RyzenAdjUI_WPF {
             }
         }
 
-        public void Button_Click (object sender, RoutedEventArgs e) {
+        public void Apply_Click (object sender, RoutedEventArgs e) {
             if (RunExe ()) {
                 MessageBox.Show ("Settings successfully applied!");
             } else {
                 MessageBox.Show ("ERROR: Failed to apply settings.");
             }
             // System.Windows.Application.Current.Shutdown();
+        }
+
+        public void Exit_Click(object sender, RoutedEventArgs e)
+        {
+            System.Windows.Application.Current.Shutdown();
         }
 
         // Returns true if successful, else returns false.

--- a/RyzenAdjUI_WPF/MainWindow.xaml.cs
+++ b/RyzenAdjUI_WPF/MainWindow.xaml.cs
@@ -171,6 +171,104 @@ namespace RyzenAdjUI_WPF {
             }
         }
 
+        public void RcheckBox7_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (rcheckBox7.Fill != Brushes.Green)
+            {
+                rcheckBox7.Fill = Brushes.Green;
+                this.Height += 200;
+            }
+            else
+            {
+                rcheckBox7.Fill = Brushes.Transparent;
+                this.Height -= 200;
+            }
+        }
+
+        private void RcheckBox8_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (rcheckBox8.Fill != Brushes.Green)
+            {
+                rcheckBox8.Fill = Brushes.Green;
+                rtextbox8.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                rcheckBox8.Fill = Brushes.Transparent;
+                rtextbox8.Visibility = Visibility.Hidden;
+            }
+        }
+
+        private void RcheckBox9_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (rcheckBox9.Fill != Brushes.Green)
+            {
+                rcheckBox9.Fill = Brushes.Green;
+                rtextbox9.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                rcheckBox9.Fill = Brushes.Transparent;
+                rtextbox9.Visibility = Visibility.Hidden;
+            }
+        }
+
+        private void RcheckBox10_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (rcheckBox10.Fill != Brushes.Green)
+            {
+                rcheckBox10.Fill = Brushes.Green;
+                rtextbox10.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                rcheckBox10.Fill = Brushes.Transparent;
+                rtextbox10.Visibility = Visibility.Hidden;
+            }
+        }
+
+        private void RcheckBox11_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (rcheckBox11.Fill != Brushes.Green)
+            {
+                rcheckBox11.Fill = Brushes.Green;
+                rtextbox11.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                rcheckBox11.Fill = Brushes.Transparent;
+                rtextbox11.Visibility = Visibility.Hidden;
+            }
+        }
+
+        private void RcheckBox12_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (rcheckBox12.Fill != Brushes.Green)
+            {
+                rcheckBox12.Fill = Brushes.Green;
+                rtextbox12.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                rcheckBox12.Fill = Brushes.Transparent;
+                rtextbox12.Visibility = Visibility.Hidden;
+            }
+        }
+
+        private void RcheckBox13_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (rcheckBox13.Fill != Brushes.Green)
+            {
+                rcheckBox13.Fill = Brushes.Green;
+                rtextbox13.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                rcheckBox13.Fill = Brushes.Transparent;
+                rtextbox13.Visibility = Visibility.Hidden;
+            }
+        }
+
         public void Apply_Click (object sender, RoutedEventArgs e) {
             if (RunExe ()) {
                 MessageBox.Show ("Settings successfully applied!");
@@ -187,12 +285,22 @@ namespace RyzenAdjUI_WPF {
 
         // Returns true if successful, else returns false.
         public bool RunExe () {
-            int spm = 15;
-            int sfl = 30;
-            int ssl = 25;
-            int tmp = 80;
-            int vrm = 30000;
+            int[] parameters_values = new int[11];
+            int spm = -1;
+            int sfl = -1;
+            int ssl = -1;
+            int tmp = -1;
+            int vrm = -1;
 
+            int spt = -1;
+            int vsc = -1;
+            int vcl = -1;
+            int vsm = -1;
+            int pcl = -1;
+            int psc = -1;
+        
+
+            string[] parameter_names = { "stapm-limit", "fast-limit", "slow-limit", "tctl-temp", "vrmmax-current", "slow-time", "vrmsoc-current", "vrm-current", "vrmsocmax-current", "psi0-current", "psi0soc-current" };
             if (rcheckBox1.Fill == Brushes.Green)
                 spm = int.Parse (slider1.Value.ToString ());
             if (rcheckBox2.Fill == Brushes.Green)
@@ -203,29 +311,94 @@ namespace RyzenAdjUI_WPF {
                 tmp = int.Parse (slider4.Value.ToString ());
             if (rcheckBox5.Fill == Brushes.Green)
                 vrm = int.Parse (slider5.Value.ToString ());
+            if (rcheckBox8.Fill == Brushes.Green && rtextbox8.Text.Trim() != "")
+                spt = int.Parse(rtextbox8.Text);
+            if (rcheckBox9.Fill == Brushes.Green && rtextbox9.Text.Trim() != "")
+                vsc = int.Parse(rtextbox9.Text);
+            if (rcheckBox10.Fill == Brushes.Green && rtextbox10.Text.Trim() != "")
+                vcl = int.Parse(rtextbox10.Text);
+            if (rcheckBox11.Fill == Brushes.Green && rtextbox11.Text.Trim() != "")
+                vsm = int.Parse(rtextbox11.Text);
+            if (rcheckBox12.Fill == Brushes.Green && rtextbox12.Text.Trim() != "")
+                pcl = int.Parse(rtextbox12.Text);
+            if (rcheckBox13.Fill == Brushes.Green && rtextbox13.Text.Trim() != "")
+                psc = int.Parse(rtextbox13.Text);
 
-            string vrmhex = vrm.ToString ("X");
+            parameters_values[0] = spm;
+            parameters_values[1] = sfl;
+            parameters_values[2] = ssl;
+            parameters_values[3] = tmp;
+            parameters_values[4] = vrm;
+            parameters_values[5] = spt;
+            parameters_values[6] = vsc;
+            parameters_values[7] = vcl;
+            parameters_values[8] = vsm;
+            parameters_values[9] = pcl;
+            parameters_values[10] = psc;
 
-            string args = $"--stapm-limit={spm}000 --fast-limit={sfl}000 --slow-limit={ssl}000 --tctl-temp={tmp} --vrmmax-current=0x{vrmhex}";
+            string args = $"";
 
-            try {
-                Process.Start (new ProcessStartInfo {
-                    FileName = $"{dir}\\ryzenadj.exe",
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                        Arguments = args,
-                        RedirectStandardOutput = true
-                });
-            } catch {
-                MessageBox.Show ("Can't find ryzenadj.exe folder");
+            int counter = 0;
+            foreach (string key in parameter_names)
+            {
+                if (parameters_values[counter] == -1)
+                {
+                }
+                else if (key == "stapm-limit" || key == "fast-limit" || key == "slow-limit")
+                {
+                    //MessageBox.Show(key + ": " + parameters_values[counter]);
+                    args += $" --{key}={parameters_values[counter]}000";
+                }
+                else if (key == "tctl-temp" || key == "slow-time")
+                {
+                    //MessageBox.Show(key + ": " + parameters_values[counter]);
+                    args += $" --{key}={parameters_values[counter]}";
+                }
+                else
+                {
+                    string hex = parameters_values[counter].ToString("X");
+                    //MessageBox.Show(key + ": " + hex);
+                    args += $" --{key}=0x{hex}";
+                }
+                counter++;
+            }
+
+            MessageBoxResult dialogResult = MessageBox.Show("Execute the following args: \n" + args, "Are you sure?", MessageBoxButton.YesNo);
+            if (dialogResult == MessageBoxResult.Yes)
+            {
+                try
+                {
+                    //Process.Start (new ProcessStartInfo {
+                    //  FileName = $"{dir}\\ryzenadj.exe",
+                    //    UseShellExecute = false,
+                    //  CreateNoWindow = true,
+                    //Arguments = args,
+                    //RedirectStandardOutput = true
+                    //});
+                }
+                catch
+                {
+                    MessageBox.Show("Can't find ryzenadj.exe folder");
+                    return false;
+                }
+                CreateBat();
+                if (rcheckBox6.Fill == Brushes.Green)
+                {
+                    AutoStart();
+                }
+                else
+                {
+                    ClearAutoStart();
+                }
+            }
+            else if (dialogResult == MessageBoxResult.No)
+            {
+                MessageBox.Show("Aborted.");
                 return false;
             }
-            CreateBat();
-            if (rcheckBox6.Fill == Brushes.Green) {
-                AutoStart ();
-            } else {
-                ClearAutoStart ();
-            }
+
+
+            
             return true;
 
         }
@@ -250,26 +423,86 @@ namespace RyzenAdjUI_WPF {
         }
 
         public void CreateBat () {
-            int spm = 15;
-            int sfl = 30;
-            int ssl = 25;
-            int tmp = 80;
-            int vrm = 30000;
+            int[] parameters_values = new int[11];
+            int spm = -1;
+            int sfl = -1;
+            int ssl = -1;
+            int tmp = -1;
+            int vrm = -1;
 
+            int spt = -1;
+            int vsc = -1;
+            int vcl = -1;
+            int vsm = -1;
+            int pcl = -1;
+            int psc = -1;
+            
+
+            string[] parameter_names = { "stapm-limit", "fast-limit", "slow-limit", "tctl-temp", "vrmmax-current", "slow-time", "vrmsoc-current", "vrm-current", "vrmsocmax-current", "psi0-current", "psi0soc-current" };
             if (rcheckBox1.Fill == Brushes.Green)
-                spm = int.Parse (slider1.Value.ToString ());
+                spm = int.Parse(slider1.Value.ToString());
             if (rcheckBox2.Fill == Brushes.Green)
-                sfl = int.Parse (slider2.Value.ToString ());
+                sfl = int.Parse(slider2.Value.ToString());
             if (rcheckBox3.Fill == Brushes.Green)
-                ssl = int.Parse (slider3.Value.ToString ());
+                ssl = int.Parse(slider3.Value.ToString());
             if (rcheckBox4.Fill == Brushes.Green)
-                tmp = int.Parse (slider4.Value.ToString ());
+                tmp = int.Parse(slider4.Value.ToString());
             if (rcheckBox5.Fill == Brushes.Green)
-                vrm = int.Parse (slider5.Value.ToString ());
+                vrm = int.Parse(slider5.Value.ToString());
+            if (rcheckBox8.Fill == Brushes.Green)
+                spt = int.Parse(rtextbox8.Text);
+            if (rcheckBox9.Fill == Brushes.Green)
+                vsc = int.Parse(rtextbox9.Text);
+            if (rcheckBox10.Fill == Brushes.Green)
+                vcl = int.Parse(rtextbox10.Text);
+            if (rcheckBox11.Fill == Brushes.Green)
+                vsm = int.Parse(rtextbox11.Text);
+            if (rcheckBox12.Fill == Brushes.Green)
+                pcl = int.Parse(rtextbox12.Text);
+            if (rcheckBox13.Fill == Brushes.Green)
+                psc = int.Parse(rtextbox13.Text);
 
-            string vrmhex = vrm.ToString ("X");
+            parameters_values[0] = spm;
+            parameters_values[1] = sfl;
+            parameters_values[2] = ssl;
+            parameters_values[3] = tmp;
+            parameters_values[4] = vrm;
+            parameters_values[5] = spt;
+            parameters_values[6] = vsc;
+            parameters_values[7] = vcl;
+            parameters_values[8] = vsm;
+            parameters_values[9] = pcl;
+            parameters_values[10] = psc;
 
-            string bat = $"%~dp0\\ryzenadj.exe --stapm-limit={spm}000 --fast-limit={sfl}000 --slow-limit={ssl}000 --tctl-temp={tmp} --vrmmax-current=0x{vrmhex}";
+            string bat = $"%~dp0\\ryzenadj.exe";
+
+            int counter = 0;
+            foreach (string key in parameter_names)
+            {
+                
+                if (parameters_values[counter] == -1)
+                {
+                    //MessageBox.Show(key + " is missing at counter " + counter);
+                }
+                else if (key == "stapm-limit" || key == "fast-limit" || key == "slow-limit")
+                {
+                    //MessageBox.Show(key + ": " + parameters_values[counter]);
+                    bat += $" --{key}={parameters_values[counter]}000";
+                }
+                else if (key == "tctl-temp" || key == "slow-time")
+                {
+                    //MessageBox.Show(key + ": " + parameters_values[counter]);
+                    bat += $" --{key}={parameters_values[counter]}";
+                }
+                else
+                {
+                    string hex = parameters_values[counter].ToString("X");
+                    //MessageBox.Show(key + ": " + hex);
+                    bat += $" --{key}=0x{hex}";
+                }
+                counter++;
+            }
+
 
             if (!File.Exists (batFilePath)) {
                 using (FileStream fs = File.Create (batFilePath)) {
@@ -342,8 +575,62 @@ namespace RyzenAdjUI_WPF {
                                 slider5.Visibility = Visibility.Visible;
                                 lab5.Visibility = Visibility.Visible;
                                 break;
+                            case "slow-time":
+                                if (rcheckBox7.Fill != Brushes.Green)
+                                {
+                                    RcheckBox7_MouseDown(null, null);
+                                }
+                                rcheckBox8.Fill = Brushes.Green;
+                                rtextbox8.Text = typeValue.Trim();
+                                rtextbox8.Visibility = Visibility.Visible;
+                                break;
+                            case "vrmsoc-current":
+                                if (rcheckBox7.Fill != Brushes.Green)
+                                {
+                                    RcheckBox7_MouseDown(null, null);
+                                }
+                                rcheckBox9.Fill = Brushes.Green;
+                                rtextbox9.Text = Convert.ToString(Convert.ToDouble(Convert.ToInt64(typeValue.Trim(), 16)));
+                                rtextbox9.Visibility = Visibility.Visible;
+                                break;
+                            case "vrm-current":
+                                if (rcheckBox7.Fill != Brushes.Green)
+                                {
+                                    RcheckBox7_MouseDown(null, null);
+                                }
+                                rcheckBox10.Fill = Brushes.Green;
+                                rtextbox10.Text = Convert.ToString(Convert.ToDouble(Convert.ToInt64(typeValue.Trim(), 16)));
+                                rtextbox10.Visibility = Visibility.Visible;
+                                break;
+                            case "vrmsocmax-current":
+                                if (rcheckBox7.Fill != Brushes.Green)
+                                {
+                                    RcheckBox7_MouseDown(null, null);
+                                }
+                                rcheckBox11.Fill = Brushes.Green;
+                                rtextbox11.Text = Convert.ToString(Convert.ToDouble(Convert.ToInt64(typeValue.Trim(), 16)));
+                                rtextbox11.Visibility = Visibility.Visible;
+                                break;
+                            case "psi0-current":
+                                if (rcheckBox7.Fill != Brushes.Green)
+                                {
+                                    RcheckBox7_MouseDown(null, null);
+                                }
+                                rcheckBox12.Fill = Brushes.Green;
+                                rtextbox12.Text = Convert.ToString(Convert.ToDouble(Convert.ToInt64(typeValue.Trim(), 16)));
+                                rtextbox12.Visibility = Visibility.Visible;
+                                break;
+                            case "psi0soc-current":
+                                if (rcheckBox7.Fill != Brushes.Green)
+                                {
+                                    RcheckBox7_MouseDown(null, null);
+                                }
+                                rcheckBox13.Fill = Brushes.Green;
+                                rtextbox13.Text = Convert.ToString(Convert.ToDouble(Convert.ToInt64(typeValue.Trim(), 16)));
+                                rtextbox13.Visibility = Visibility.Visible;
+                                break;
                             default:
-
+                                MessageBox.Show("WARN: Unsupported settings value: " + type + " with the value of: " + typeValue + " has been ignored.");
                                 break;
                         }
                         //MessageBox.Show(type);
@@ -352,5 +639,6 @@ namespace RyzenAdjUI_WPF {
             }
         }
 
+        
     }
 }

--- a/RyzenAdjUI_WPF/MainWindow.xaml.cs
+++ b/RyzenAdjUI_WPF/MainWindow.xaml.cs
@@ -368,13 +368,13 @@ namespace RyzenAdjUI_WPF {
             {
                 try
                 {
-                    //Process.Start (new ProcessStartInfo {
-                    //  FileName = $"{dir}\\ryzenadj.exe",
-                    //    UseShellExecute = false,
-                    //  CreateNoWindow = true,
-                    //Arguments = args,
-                    //RedirectStandardOutput = true
-                    //});
+                    Process.Start (new ProcessStartInfo {
+                      FileName = $"{dir}\\ryzenadj.exe",
+                        UseShellExecute = false,
+                      CreateNoWindow = true,
+                    Arguments = args,
+                    RedirectStandardOutput = true
+                    });
                 }
                 catch
                 {

--- a/RyzenAdjUI_WPF/MainWindow.xaml.cs
+++ b/RyzenAdjUI_WPF/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Win32;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -7,11 +6,10 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
+using Microsoft.Win32;
 
-namespace RyzenAdjUI_WPF
-{
-    internal enum AccentState
-    {
+namespace RyzenAdjUI_WPF {
+    internal enum AccentState {
         ACCENT_DISABLED = 1,
         ACCENT_ENABLE_GRADIENT = 0,
         ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
@@ -19,25 +17,22 @@ namespace RyzenAdjUI_WPF
         ACCENT_INVALID_STATE = 4
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct AccentPolicy
-    {
+    [StructLayout (LayoutKind.Sequential)]
+    internal struct AccentPolicy {
         public AccentState AccentState;
         public int AccentFlags;
         public int GradientColor;
         public int AnimationId;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct WindowCompositionAttributeData
-    {
+    [StructLayout (LayoutKind.Sequential)]
+    internal struct WindowCompositionAttributeData {
         public WindowCompositionAttribute Attribute;
         public IntPtr Data;
         public int SizeOfData;
     }
 
-    internal enum WindowCompositionAttribute
-    {
+    internal enum WindowCompositionAttribute {
         // ...
         WCA_ACCENT_POLICY = 19
         // ...
@@ -45,62 +40,56 @@ namespace RyzenAdjUI_WPF
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
-    {
-        private string dir = System.IO.Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+    public partial class MainWindow : Window {
+        private static string dir = System.IO.Path.GetDirectoryName (Process.GetCurrentProcess ().MainModule.FileName);
+        private static string settingsFileName = "settings.bat";
+        private string batFilePath = $"{dir}\\{settingsFileName}";
 
-        [DllImport("user32.dll")]
-        internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
+        [DllImport ("user32.dll")]
+        internal static extern int SetWindowCompositionAttribute (IntPtr hwnd, ref WindowCompositionAttributeData data);
 
-        public MainWindow()
-        {
-            InitializeComponent();
+        public MainWindow () {
+            InitializeComponent ();
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
-        {
-            EnableBlur();
+        private void Window_Loaded (object sender, RoutedEventArgs e) {
+            EnableBlur ();
+            loadSettings();
         }
 
-        internal void EnableBlur()
-        {
-            var windowHelper = new WindowInteropHelper(this);
+        internal void EnableBlur () {
+            var windowHelper = new WindowInteropHelper (this);
 
-            var accent = new AccentPolicy();
+            var accent = new AccentPolicy ();
             accent.AccentState = AccentState.ACCENT_ENABLE_BLURBEHIND;
 
-            var accentStructSize = Marshal.SizeOf(accent);
+            var accentStructSize = Marshal.SizeOf (accent);
 
-            var accentPtr = Marshal.AllocHGlobal(accentStructSize);
-            Marshal.StructureToPtr(accent, accentPtr, false);
+            var accentPtr = Marshal.AllocHGlobal (accentStructSize);
+            Marshal.StructureToPtr (accent, accentPtr, false);
 
-            var data = new WindowCompositionAttributeData();
+            var data = new WindowCompositionAttributeData ();
             data.Attribute = WindowCompositionAttribute.WCA_ACCENT_POLICY;
             data.SizeOfData = accentStructSize;
             data.Data = accentPtr;
 
-            SetWindowCompositionAttribute(windowHelper.Handle, ref data);
+            SetWindowCompositionAttribute (windowHelper.Handle, ref data);
 
-            Marshal.FreeHGlobal(accentPtr);
+            Marshal.FreeHGlobal (accentPtr);
         }
 
-        private void Window_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            DragMove();
+        private void Window_MouseDown (object sender, System.Windows.Input.MouseButtonEventArgs e) {
+            DragMove ();
         }
 
-        public void RcheckBox1_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (rcheckBox1.Fill != Brushes.Green)
-            {
+        public void RcheckBox1_MouseDown (object sender, MouseButtonEventArgs e) {
+            if (rcheckBox1.Fill != Brushes.Green) {
                 rcheckBox1.Fill = Brushes.Green;
                 cube1.Visibility = Visibility.Visible;
                 rect1s.Visibility = Visibility.Visible;
                 slider1.Visibility = Visibility.Visible;
                 lab1.Visibility = Visibility.Visible;
-            }
-            else
-            {
+            } else {
                 rcheckBox1.Fill = Brushes.Transparent;
                 cube1.Visibility = Visibility.Hidden;
                 rect1s.Visibility = Visibility.Hidden;
@@ -110,18 +99,14 @@ namespace RyzenAdjUI_WPF
 
         }
 
-        public void RcheckBox2_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (rcheckBox2.Fill != Brushes.Green)
-            {
+        public void RcheckBox2_MouseDown (object sender, MouseButtonEventArgs e) {
+            if (rcheckBox2.Fill != Brushes.Green) {
                 rcheckBox2.Fill = Brushes.Green;
                 cube2.Visibility = Visibility.Visible;
                 rect2s.Visibility = Visibility.Visible;
                 slider2.Visibility = Visibility.Visible;
                 lab2.Visibility = Visibility.Visible;
-            }
-            else
-            {
+            } else {
                 rcheckBox2.Fill = Brushes.Transparent;
                 cube2.Visibility = Visibility.Hidden;
                 rect2s.Visibility = Visibility.Hidden;
@@ -130,18 +115,14 @@ namespace RyzenAdjUI_WPF
             }
         }
 
-        public void RcheckBox3_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (rcheckBox3.Fill != Brushes.Green)
-            {
+        public void RcheckBox3_MouseDown (object sender, MouseButtonEventArgs e) {
+            if (rcheckBox3.Fill != Brushes.Green) {
                 rcheckBox3.Fill = Brushes.Green;
                 cube3.Visibility = Visibility.Visible;
                 rect3s.Visibility = Visibility.Visible;
                 slider3.Visibility = Visibility.Visible;
                 lab3.Visibility = Visibility.Visible;
-            }
-            else
-            {
+            } else {
                 rcheckBox3.Fill = Brushes.Transparent;
                 cube3.Visibility = Visibility.Hidden;
                 rect3s.Visibility = Visibility.Hidden;
@@ -150,18 +131,14 @@ namespace RyzenAdjUI_WPF
             }
         }
 
-        public void RcheckBox4_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (rcheckBox4.Fill != Brushes.Green)
-            {
+        public void RcheckBox4_MouseDown (object sender, MouseButtonEventArgs e) {
+            if (rcheckBox4.Fill != Brushes.Green) {
                 rcheckBox4.Fill = Brushes.Green;
                 cube4.Visibility = Visibility.Visible;
                 rect4s.Visibility = Visibility.Visible;
                 slider4.Visibility = Visibility.Visible;
                 lab4.Visibility = Visibility.Visible;
-            }
-            else
-            {
+            } else {
                 rcheckBox4.Fill = Brushes.Transparent;
                 cube4.Visibility = Visibility.Hidden;
                 rect4s.Visibility = Visibility.Hidden;
@@ -170,18 +147,14 @@ namespace RyzenAdjUI_WPF
             }
         }
 
-        public void RcheckBox5_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (rcheckBox5.Fill != Brushes.Green)
-            {
+        public void RcheckBox5_MouseDown (object sender, MouseButtonEventArgs e) {
+            if (rcheckBox5.Fill != Brushes.Green) {
                 rcheckBox5.Fill = Brushes.Green;
                 cube5.Visibility = Visibility.Visible;
                 rect5s.Visibility = Visibility.Visible;
                 slider5.Visibility = Visibility.Visible;
                 lab5.Visibility = Visibility.Visible;
-            }
-            else
-            {
+            } else {
                 rcheckBox5.Fill = Brushes.Transparent;
                 cube5.Visibility = Visibility.Hidden;
                 rect5s.Visibility = Visibility.Hidden;
@@ -190,126 +163,189 @@ namespace RyzenAdjUI_WPF
             }
         }
 
-        public void RcheckBox6_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            if (rcheckBox6.Fill != Brushes.Green)
-            {
+        public void RcheckBox6_MouseDown (object sender, MouseButtonEventArgs e) {
+            if (rcheckBox6.Fill != Brushes.Green) {
                 rcheckBox6.Fill = Brushes.Green;
-            }
-            else
-            {
+            } else {
                 rcheckBox6.Fill = Brushes.Transparent;
             }
         }
 
-        public void Button_Click(object sender, RoutedEventArgs e)
-        {
-            RunExe();
-            MessageBox.Show("Success!");
-            System.Windows.Application.Current.Shutdown();
+        public void Button_Click (object sender, RoutedEventArgs e) {
+            if (RunExe ()) {
+                MessageBox.Show ("Settings successfully applied!");
+            } else {
+                MessageBox.Show ("ERROR: Failed to apply settings.");
+            }
+            // System.Windows.Application.Current.Shutdown();
         }
 
-        public void RunExe()
-        {
-            int spm = 15; int sfl = 30; int ssl = 25; int tmp = 80; int vrm = 30000;
+        // Returns true if successful, else returns false.
+        public bool RunExe () {
+            int spm = 15;
+            int sfl = 30;
+            int ssl = 25;
+            int tmp = 80;
+            int vrm = 30000;
 
             if (rcheckBox1.Fill == Brushes.Green)
-                spm = int.Parse(slider1.Value.ToString());
+                spm = int.Parse (slider1.Value.ToString ());
             if (rcheckBox2.Fill == Brushes.Green)
-                sfl = int.Parse(slider2.Value.ToString());
+                sfl = int.Parse (slider2.Value.ToString ());
             if (rcheckBox3.Fill == Brushes.Green)
-                ssl = int.Parse(slider3.Value.ToString());
+                ssl = int.Parse (slider3.Value.ToString ());
             if (rcheckBox4.Fill == Brushes.Green)
-                tmp = int.Parse(slider4.Value.ToString());
+                tmp = int.Parse (slider4.Value.ToString ());
             if (rcheckBox5.Fill == Brushes.Green)
-                vrm = int.Parse(slider5.Value.ToString());
+                vrm = int.Parse (slider5.Value.ToString ());
 
-            string vrmhex = vrm.ToString("X");
+            string vrmhex = vrm.ToString ("X");
 
             string args = $"--stapm-limit={spm}000 --fast-limit={sfl}000 --slow-limit={ssl}000 --tctl-temp={tmp} --vrmmax-current=0x{vrmhex}";
 
-            try
-            {
-                Process.Start(new ProcessStartInfo
-                {
+            try {
+                Process.Start (new ProcessStartInfo {
                     FileName = $"{dir}\\ryzenadj.exe",
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    Arguments = args,
-                    RedirectStandardOutput = true
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        Arguments = args,
+                        RedirectStandardOutput = true
                 });
+            } catch {
+                MessageBox.Show ("Can't find ryzenadj.exe folder");
+                return false;
             }
-
-            catch
-            {
-                MessageBox.Show("Can't find ryzenadj.exe folder");
+            CreateBat();
+            if (rcheckBox6.Fill == Brushes.Green) {
+                AutoStart ();
+            } else {
+                ClearAutoStart ();
             }
+            return true;
 
-            if (rcheckBox6.Fill == Brushes.Green)
+        }
+
+        public void AutoStart () {
+            RegistryKey rkey = Registry.CurrentUser.OpenSubKey ("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
+            if (File.Exists(batFilePath))
             {
-                AutoStart();
+                rkey.SetValue("RyzenAdj", batFilePath);
             }
             else
             {
-                ClearAutoStart();
-            }
-
-        }
-
-        public void AutoStart()
-        {
-            var batFile = CreateBat();
-            RegistryKey rkey = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
-            rkey.SetValue("RyzenAdj", batFile);
-        }
-
-        public void ClearAutoStart()
-        {
-            RegistryKey rkey = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
-            if ((string)rkey.GetValue("RyzenAdj") != null)
-            {
-                rkey.DeleteValue("RyzenAdj");
+                MessageBox.Show("configuration file does not exist at path: " + batFilePath);
             }
         }
 
-        public string CreateBat()
-        {
-            int spm = 15; int sfl = 30; int ssl = 25; int tmp = 80; int vrm = 30000;
+        public void ClearAutoStart () {
+            RegistryKey rkey = Registry.CurrentUser.OpenSubKey ("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
+            if ((string) rkey.GetValue ("RyzenAdj") != null) {
+                rkey.DeleteValue ("RyzenAdj");
+            }
+        }
+
+        public void CreateBat () {
+            int spm = 15;
+            int sfl = 30;
+            int ssl = 25;
+            int tmp = 80;
+            int vrm = 30000;
 
             if (rcheckBox1.Fill == Brushes.Green)
-                spm = int.Parse(slider1.Value.ToString());
+                spm = int.Parse (slider1.Value.ToString ());
             if (rcheckBox2.Fill == Brushes.Green)
-                sfl = int.Parse(slider2.Value.ToString());
+                sfl = int.Parse (slider2.Value.ToString ());
             if (rcheckBox3.Fill == Brushes.Green)
-                ssl = int.Parse(slider3.Value.ToString());
+                ssl = int.Parse (slider3.Value.ToString ());
             if (rcheckBox4.Fill == Brushes.Green)
-                tmp = int.Parse(slider4.Value.ToString());  
+                tmp = int.Parse (slider4.Value.ToString ());
             if (rcheckBox5.Fill == Brushes.Green)
-                vrm = int.Parse(slider5.Value.ToString());
+                vrm = int.Parse (slider5.Value.ToString ());
 
-            string vrmhex = vrm.ToString("X");
+            string vrmhex = vrm.ToString ("X");
 
-            string batFilePath = $"{dir}\\autostart.bat";
             string bat = $"%~dp0\\ryzenadj.exe --stapm-limit={spm}000 --fast-limit={sfl}000 --slow-limit={ssl}000 --tctl-temp={tmp} --vrmmax-current=0x{vrmhex}";
 
-            if (!File.Exists(batFilePath))
-            {
-                using (FileStream fs = File.Create(batFilePath))
-                {
-                    fs.Close();
+            if (!File.Exists (batFilePath)) {
+                using (FileStream fs = File.Create (batFilePath)) {
+                    fs.Close ();
                 }
             }
 
-            using (StreamWriter sw = new StreamWriter(batFilePath))
-            {
-                sw.WriteLine(bat);
+            using (StreamWriter sw = new StreamWriter (batFilePath)) {
+                sw.WriteLine (bat);
             }
-
-            return batFilePath;
-
-
         }
 
+        public void loadSettings ()
+        {
+            string contents = "";
+            string[] values = null;
+            if (File.Exists(batFilePath)) {
+                contents = File.ReadAllText(batFilePath);
+                values = contents.Split(new[] { "--" }, StringSplitOptions.None);
+                // Separate the batch file into arguments @ values[]
+
+                foreach (string s in values)
+                {
+                    //MessageBox.Show(s);
+                    if (s.Contains("="))
+                    {
+                        string[] settingsArg = s.Split('=');
+                        string type = settingsArg[0];
+                        string typeValue = settingsArg[1];
+
+                        switch (type)
+                        {
+                            case "stapm-limit":
+                                rcheckBox1.Fill = Brushes.Green;
+                                slider1.Value = double.Parse(typeValue);
+                                cube1.Visibility = Visibility.Visible;
+                                rect1s.Visibility = Visibility.Visible;
+                                slider1.Visibility = Visibility.Visible;
+                                lab1.Visibility = Visibility.Visible;
+                                break;
+                            case "fast-limit":
+                                rcheckBox2.Fill = Brushes.Green;
+                                slider2.Value = double.Parse(typeValue);
+                                cube2.Visibility = Visibility.Visible;
+                                rect2s.Visibility = Visibility.Visible;
+                                slider2.Visibility = Visibility.Visible;
+                                lab2.Visibility = Visibility.Visible;
+                                break;
+                            case "slow-limit":
+                                rcheckBox3.Fill = Brushes.Green;
+                                slider3.Value = double.Parse(typeValue);
+                                cube3.Visibility = Visibility.Visible;
+                                rect3s.Visibility = Visibility.Visible;
+                                slider3.Visibility = Visibility.Visible;
+                                lab3.Visibility = Visibility.Visible;
+                                break;
+                            case "tctl-temp":
+                                rcheckBox4.Fill = Brushes.Green;
+                                slider4.Value = double.Parse(typeValue);
+                                cube4.Visibility = Visibility.Visible;
+                                rect4s.Visibility = Visibility.Visible;
+                                slider4.Visibility = Visibility.Visible;
+                                lab4.Visibility = Visibility.Visible;
+                                break;
+                            case "vrmmax-current":
+                                rcheckBox5.Fill = Brushes.Green;
+                                slider5.Value = Convert.ToDouble(Convert.ToInt64(typeValue.Trim(), 16));
+                                cube5.Visibility = Visibility.Visible;
+                                rect5s.Visibility = Visibility.Visible;
+                                slider5.Visibility = Visibility.Visible;
+                                lab5.Visibility = Visibility.Visible;
+                                break;
+                            default:
+
+                                break;
+                        }
+                        //MessageBox.Show(type);
+                    }
+                }
+            }
+        }
 
     }
 }


### PR DESCRIPTION
This PR contains the following update:

* Add:
   - Advanced menu
     - "slow-time", "vrmsoc-current", "vrm-current", "vrmsocmax-current", "psi0-current", "psi0soc-current"
     - Relevant button handlers
     - Relevant settings loading @ loadSettings ()
   - Confirmation prompt with all arguments queued prior to applying settings

* Modify:
   - VRM Max current text
   - Refactored runExe()

* Test cases:
   - Nonexistent settings file
   - Settings file with missing arguments
   - Settings with populated arguments