### PR TITLE
Fixed ucrtbased.dll missing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ AUX_SOURCE_DIRECTORY(./ SRC_DIR)
 
 if(WIN32)
 ADD_EXECUTABLE(${PROJECT_NAME} lib/winring0.cpp lib/nb_smu_ops.c lib/api.c argparse.c main.c)
+target_compile_options(${PROJECT_NAME} PRIVATE "/MT")
+target_compile_options(${PROJECT_NAME} PRIVATE "/GL")
 target_link_libraries(${PROJECT_NAME} WinRing0x64)
 ADD_LIBRARY (libryzenadj SHARED lib/winring0.cpp lib/nb_smu_ops.c lib/api.c)
 SET_TARGET_PROPERTIES(libryzenadj PROPERTIES LINKER_LANGUAGE C)   


### PR DESCRIPTION
This should fix ucrtbased.dll missing