### PR TITLE
Fix typo: CPU family renoir

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -100,7 +100,7 @@ EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x1a);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x14);
 	}
 }
@@ -112,7 +112,7 @@ EXP int CALL set_fast_limit(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x1b);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x15);
 	}
 }
@@ -124,7 +124,7 @@ EXP int CALL set_slow_limit(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x1c);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x16);
 	}
 }
@@ -136,7 +136,7 @@ EXP int CALL set_slow_time(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x1d);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x17);
 	}
 }
@@ -148,7 +148,7 @@ EXP int CALL set_stapm_time(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x1e);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x18);
 	}
 }
@@ -160,7 +160,7 @@ EXP int CALL set_tctl_temp(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x1f);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x19);
 	}
 }
@@ -172,7 +172,7 @@ EXP int CALL set_vrm_current(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x20);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x1a);
 	}
 }
@@ -184,7 +184,7 @@ EXP int CALL set_vrmsoc_current(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x21);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x1b);
 	}
 }
@@ -196,7 +196,7 @@ EXP int CALL set_vrmmax_current(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x22);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x1c);
 	}
 }
@@ -208,7 +208,7 @@ EXP int CALL set_vrmsocmax_current(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x23);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x1d);
 	}
 }
@@ -220,7 +220,7 @@ EXP int CALL set_psi0_current(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x24);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x1e);
 	}
 }
@@ -232,7 +232,7 @@ EXP int CALL set_psi0soc_current(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x25);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x20);
 	}
 }
@@ -244,7 +244,7 @@ EXP int CALL set_max_gfxclk_freq(ryzen_access ry, uint32_t value) {
 	case FAM_PICASSO:
 		_do_adjust(0x46);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -256,7 +256,7 @@ EXP int CALL set_min_gfxclk_freq(ryzen_access ry, uint32_t value) {
 	case FAM_PICASSO:
 		_do_adjust(0x47);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -268,7 +268,7 @@ EXP int CALL set_max_socclk_freq(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x48);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -280,7 +280,7 @@ EXP int CALL set_min_socclk_freq(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x49); 
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -292,7 +292,7 @@ EXP int CALL set_max_fclk_freq(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x4A);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -304,7 +304,7 @@ EXP int CALL set_min_fclk_freq(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x4B);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -316,7 +316,7 @@ EXP int CALL set_max_vcn(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x4C);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -328,7 +328,7 @@ EXP int CALL set_min_vcn(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x4D);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -340,7 +340,7 @@ EXP int CALL set_max_lclk(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x4E);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -352,7 +352,7 @@ EXP int CALL set_min_lclk(ryzen_access ry, uint32_t value){
 	case FAM_PICASSO:
 		_do_adjust(0x4F);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		break;
 	}
 }
@@ -364,7 +364,7 @@ EXP int CALL set_prochot_deassertion_ramp(ryzen_access ry, uint32_t value) {
 	case FAM_PICASSO:
 		_do_adjust(0x26);
 		break;
-	case FAM_RENIOR:
+	case FAM_RENOIR:
 		_do_adjust(0x20);
 		break;
 	}

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -61,8 +61,8 @@ enum ryzen_family cpuid_get_family()
         return FAM_PICASSO;
         break;
     case 96:
-        printf("Detected Renior\n");
-        return FAM_RENIOR;
+        printf("Detected Renoir\n");
+        return FAM_RENOIR;
         break;
     default:
         printf("Unknown Ryzen processor, won't work\n");

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -16,7 +16,7 @@ enum ryzen_family {
         FAM_UNKNOWN = -1,
         FAM_RAVEN = 0,
         FAM_PICASSO,
-        FAM_RENIOR,
+        FAM_RENOIR,
         FAM_END
 };
 

--- a/main.c
+++ b/main.c
@@ -39,8 +39,8 @@ static const char *family_name(enum ryzen_family fam)
 	case FAM_PICASSO:
 		return "Picasso";
 		break;
-	case FAM_RENIOR:
-		return "Renior";
+	case FAM_RENOIR:
+		return "Renoir";
 		break;
 	default:
 		break;


### PR DESCRIPTION
Renaming "Renior" to "Renoir"