### PR TITLE
main: Use %d instead of %x to format the value

### DIFF
--- a/main.c
+++ b/main.c
@@ -13,7 +13,7 @@
 do{ \
 	while(ARG != 0){    \
 		if(!set_##ARG(ry, ARG)){   \
-			printf("Sucessfully set " STRINGIFY(ARG) " to %x\n", ARG);    \
+			printf("Sucessfully set " STRINGIFY(ARG) " to %d\n", ARG);    \
 			break;  \
 		} else {    \
 			printf("Failed to set" STRINGIFY(ARG) " \n");   \


### PR DESCRIPTION
All values set through ryzenadj CLI are of u32 type and are provided as
integers. Displaying them in hex format is confusing.

Before this change:

```
❯ sudo ./ryzenadj --tctl-temp=85
Detected Renoir
Sucessfully set tctl_temp to 55
```

After this change:

```
❯ sudo ./ryzenadj --tctl-temp=85
Detected Renoir
Sucessfully set tctl_temp to 85
```

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>