### PR TITLE
set stapm time is not supported on renoir

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -162,7 +162,8 @@ EXP int CALL set_stapm_time(ryzen_access ry, uint32_t value){
 		break;
 	case FAM_RENOIR:
 	case FAM_CEZANNE:
-		_do_adjust(0x18);
+		//based on PICASSO order of messages it should be 0x18 for RENOIR or CEZANNE, but doesn't work for them
+		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }


### PR DESCRIPTION
@sbski you did introduce the 0x18 based on message order. Could you get it to work on your renoir device?
I couldn't.

- can't find any value change in the ptable
- doesn't seem to have any effect on long time, short time power limit
- can not see any difference in the cooldown times after boost time limit got hit 

And if you could get it to work on renoir either, could you have a look on cezanne, please?