### PR TITLE
document that prochot-deassertion-ramp is not in ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Settings
     -v, --min-lclk=<u32>                  Minimum Data Launch Clock (Value)
     -w, --max-gfxclk=<u32>                Maximum GFX Clock (Value)
     -x, --min-gfxclk=<u32>                Minimum GFX Clock (Value)
-    -y, --prochot-deassertion-ramp=<u32>  Time to ramp clocks after PROCHOT is deasserted (ms)
+    -y, --prochot-deassertion-ramp=<u32>  Ramp Time After Prochot is Deasserted (Value): limit power based on value, higher values does apply tighter limits after prochot is over
     --apu-skin-temp=<u32>                 APU Skin Temperature Limit (degree C)
     --dgpu-skin-temp=<u32>                dGPU Skin Temperature Limit (degree C)
     --apu-slow-limit=<u32>                APU PPT Slow Power limit for A+A dGPU platform (mW)

--- a/main.c
+++ b/main.c
@@ -102,7 +102,7 @@ int main(int argc, const char **argv)
 		OPT_U32('v', "min-lclk", &min_lclk, "Minimum Data Launch Clock (MHz)"),
 		OPT_U32('w', "max-gfxclk", &max_gfxclk_freq, "Maximum GFX Clock (MHz)"),
 		OPT_U32('x', "min-gfxclk", &min_gfxclk_freq, "Minimum GFX Clock (MHz)"),
-		OPT_U32('y', "prochot-deassertion-ramp", &prochot_deassertion_ramp, "Time To Ramp Clocks After Prochot is Deasserted (ms)"),
+		OPT_U32('y', "prochot-deassertion-ramp", &prochot_deassertion_ramp, "Ramp Time After Prochot is Deasserted: limit power based on value, higher values does apply tighter limits after prochot is over"),
 		OPT_U32('\0', "apu-skin-temp", &apu_skin_temp_limit, "APU Skin Temperature Limit (degree C)"),
 		OPT_U32('\0', "dgpu-skin-temp", &dgpu_skin_temp_limit, "dGPU Skin Temperature Limit (degree C)"),
 		OPT_U32('\0', "apu-slow-limit", &apu_slow_limit, "APU PPT Slow Power limit for A+A dGPU platform (mW)"),


### PR DESCRIPTION
Still don't know how prochot-deassertion-ramp does work, at least it is nothing in s or ms. I can only confirm that this does handle the limit applyment after prochot gets released. So I changed the documentation.
If I use values below ~256 (0x100) nothing happens: feels like limit after prochot for values lower then 256 does exceed my thermal capacity right after a prochot. Which means after a fixed amount of prochot the limit gets so loose that power spikes right from 4W (prochot power limit) up to max power draw possible for my current tctl temperature (maybe 25W).
But larger values does limit my power draw after prochot:
- before prochot 45W to 30W depending on temperature until prochot kicks in
- 4W during prochot
- after prochot gets released I have 15W  for value ~300 or 6W for values like ~20.000
- after prochot gets released limit stays for at least 10 minutes (didn't test more then 10 minutes for the small value of 300)

After 10 minutes running cinebench at 15W I did set prochot values like 64 which is so low that right after applying my power draw goes up to maximum.

I did then a run with 20 000 which does cool down my laptop very fast because for such large values I get only ~6W after prochot gets released. Based on the fast falling temperature I did expect a change in power draw. But after prochot, limit stays the same at ~6W until I lower the prochot-deassertion-ramp value.