### PR TITLE
avoid sending wrong messages to desktop renoir

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -12,9 +12,12 @@ EXP ryzen_access CALL init_ryzenadj()
 	if (family == FAM_UNKNOWN)
 		return NULL;
 
+	int package_type = cpuid_get_package_type();
+
 	ry = (ryzen_access)malloc((sizeof(*ry)));
 
 	ry->family = family;
+	ry->package_type = package_type;
 
 	ry->pci_obj = init_pci_obj();
 	if(!ry->pci_obj){
@@ -78,6 +81,11 @@ EXP enum ryzen_family get_cpu_family(ryzen_access ry)
 EXP int get_bios_if_ver(ryzen_access ry)
 {
 	return ry->bios_if_ver;
+}
+
+EXP int get_cpu_package_type(ryzen_access ry)
+{
+	return ry->package_type;
 }
 
 #define _do_adjust(OPT) \

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -26,7 +26,7 @@ static void getcpuid(unsigned int CPUInfo[4], unsigned int InfoType)
 enum ryzen_family cpuid_get_family()
 {
     uint32_t regs[4];
-    int family, model, packagetype;
+    int family, model;
     char vendor[4 * 4];
 
     getcpuid(regs, 0);
@@ -45,9 +45,6 @@ enum ryzen_family cpuid_get_family()
 
     family = ((regs[0] >> 8) & 0xf) + ((regs[0] >> 20) & 0xff);
     model = ((regs[0] >> 4) & 0xf) | ((regs[0] >> 12) & 0xf0);
-    //0 = FP6, 2 = AM4, 7 = SP3
-    packagetype = regs[1] >> 28;
-    printf("Package Type:  %d\n", packagetype);
 
     switch (family) {
     case 0x17: /* Zen, Zen+, Zen2 */
@@ -84,4 +81,12 @@ enum ryzen_family cpuid_get_family()
     }
 
     return FAM_UNKNOWN;
+}
+
+int cpuid_get_package_type()
+{
+    uint32_t regs[4];
+    getcpuid(regs, 0x80000001);
+    //0 = FP6, 2 = AM4, 7 = SP3
+    return regs[1] >> 28;
 }

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -26,7 +26,7 @@ static void getcpuid(unsigned int CPUInfo[4], unsigned int InfoType)
 enum ryzen_family cpuid_get_family()
 {
     uint32_t regs[4];
-    int family, model;
+    int family, model, packagetype;
     char vendor[4 * 4];
 
     getcpuid(regs, 0);
@@ -45,6 +45,9 @@ enum ryzen_family cpuid_get_family()
 
     family = ((regs[0] >> 8) & 0xf) + ((regs[0] >> 20) & 0xff);
     model = ((regs[0] >> 4) & 0xf) | ((regs[0] >> 12) & 0xf0);
+    //0 = FP6, 2 = AM4, 7 = SP3
+    packagetype = regs[1] >> 28;
+    printf("Package Type:  %d\n", packagetype);
 
     switch (family) {
     case 0x17: /* Zen, Zen+, Zen2 */

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -58,6 +58,7 @@ EXP void CALL cleanup_ryzenadj(ryzen_access ry);
 
 EXP enum ryzen_family get_cpu_family(ryzen_access ry);
 EXP int get_bios_if_ver(ryzen_access ry);
+EXP int get_cpu_package_type(ryzen_access ry);
 
 EXP int CALL set_stapm_limit(ryzen_access, uint32_t value);
 EXP int CALL set_fast_limit(ryzen_access, uint32_t value);

--- a/lib/ryzenadj_priv.h
+++ b/lib/ryzenadj_priv.h
@@ -20,8 +20,10 @@ struct _ryzen_access {
 	smu_t psmu;
 	enum ryzen_family family;
 	int bios_if_ver;
+	int package_type;
 };
 
 enum ryzen_family cpuid_get_family();
+int cpuid_get_package_type();
 
 #endif

--- a/main.c
+++ b/main.c
@@ -61,7 +61,9 @@ static const char *family_name(enum ryzen_family fam)
 static void show_info(ryzen_access ry)
 {
 	printf("CPU Family: %s\n", family_name(get_cpu_family(ry)));
+	printf("CPU Package Type: %d\n", get_cpu_package_type(ry));
 	printf("SMU BIOS Interface Version: %d\n", get_bios_if_ver(ry));
+	printf("Version: v" STRINGIFY(RYZENADJ_REVISION_VER) "." STRINGIFY(RYZENADJ_MAJOR_VER) "." STRINGIFY(RYZENADJ_MINIOR_VER) " \n");
 }
 
 int main(int argc, const char **argv)


### PR DESCRIPTION
Based on this discussion https://github.com/FlyGoat/ryzen_nb_smu/issues/5
I would like to differentiate between desktop and mobile Renoir using package type.

Because I expect people of the UI Ryzen Controller less careful and I would rather have users who get an unsupported error message to ask "What can I do to get it supported?" instead of people sending wrong messages to their systems.

The current version of this PR does adapt your get_cpu_family method structure.

But it would be much shorter and more readable if I would refactor our `FAM_RENOIR` to `FAM_RENOIR_MOBILE` because I could get the package type check right into the get family method, like I did in the first commit https://github.com/FlyGoat/RyzenAdj/commit/bc4719c28c1c2c65e9203a930f42c2330ee27039

What do you think? Would you approve a refactoring to `FAM_RENOIR_MOBILE` and `FAM_PICCASSO_MOBILE`? 
I could already add support for PPT, TDC EDC on  `FAM_RENOIR_DESKTOP` and `FAM_PICCASSO_DESKTOP`
We could also introduce an SMU version check, but SMU versions are more likely to be compatible with each other.  I just worry about Desktop vs Mobile because we already know that there are differences, and it makes sense because there are messages like PowerSourceAC/PowerSourceDC which are uncommon for a desktop platform.

Open TODOs:
- [ ] unsupported error message for Renoir CPUs with package type != 0 (refactor `FAM_RENOIR`  and  `FAM_PICCASSO` to  `FAM_RENOIR_MOBILE` and `FAM_PICCASSO_MOBILE`)
- [ ] add PPT, TDC EDC support for `FAM_RENOIR_DESKTOP` and `FAM_PICCASSO_DESKTOP`
- [ ] improve commit message