### PR TITLE
add Linux Build action with highlighting of build results

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,21 @@
+name: Linux Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: Ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: sudo apt install libpci-dev
+
+    - name: run-cmake
+      uses: lukka/run-cmake@v3.3
+

--- a/argparse.c
+++ b/argparse.c
@@ -379,7 +379,7 @@ argparse_usage(struct argparse *self)
 	options = self->options;
 	for (; options->type != ARGPARSE_OPT_END; options++) {
 		size_t pos = 0;
-		int pad    = 0;
+		size_t pad = 0;
 		if (options->type == ARGPARSE_OPT_GROUP) {
 			fputc('\n', stdout);
 			fprintf(stdout, "%s", options->help);
@@ -411,7 +411,7 @@ argparse_usage(struct argparse *self)
 			fputc('\n', stdout);
 			pad = usage_opts_width;
 		}
-		fprintf(stdout, "%*s%s\n", pad + 2, "", options->help);
+		fprintf(stdout, "%*s%s\n", (int)pad + 2, "", options->help);
 	}
 
 	// print epilog


### PR DESCRIPTION
warnings and errors get visible inline at github diff view
fix small arg parse warnings

This makes work so much more easy. 
And the Linux build is much faster.

Source of this idea was the need to test if Linux build is still working