### PR TITLE
2 in 1: add Linux Build action with highlighting of build results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Windows Build
+name: Build
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  Windows:
     runs-on: windows-latest
 
     steps:
@@ -43,3 +43,15 @@ jobs:
             ./lib/ryzenadj.h
             ./prebuilt/WinRing0x64.dll
             ./prebuilt/WinRing0x64.sys
+
+  Linux:
+    runs-on: Ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: sudo apt install libpci-dev
+
+    - name: run-cmake
+      uses: lukka/run-cmake@v3.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,25 @@ jobs:
 
     - uses: ilammy/msvc-dev-cmd@v1
 
-    - name: Build
+    #don't use run-cmake for windows because only one build should add warnings to pull request
+    - name: Build Debug
+      run: |
+        mkdir debug
+        cd debug
+        cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
+        nmake
+
+    - name: Upload ryzenadj debug
+      uses: actions/upload-artifact@v2
+      with:
+        name: ryzenadj-win64-debug
+        path: |
+            ./debug/ryzenadj.exe
+            ./prebuilt/WinRing0x64.dll
+            ./prebuilt/WinRing0x64.sys
+            ./prebuilt/demo.bat
+
+    - name: Build Release
       run: |
         mkdir build
         cd build

--- a/argparse.c
+++ b/argparse.c
@@ -379,7 +379,7 @@ argparse_usage(struct argparse *self)
 	options = self->options;
 	for (; options->type != ARGPARSE_OPT_END; options++) {
 		size_t pos = 0;
-		int pad    = 0;
+		size_t pad = 0;
 		if (options->type == ARGPARSE_OPT_GROUP) {
 			fputc('\n', stdout);
 			fprintf(stdout, "%s", options->help);
@@ -411,7 +411,7 @@ argparse_usage(struct argparse *self)
 			fputc('\n', stdout);
 			pad = usage_opts_width;
 		}
-		fprintf(stdout, "%*s%s\n", pad + 2, "", options->help);
+		fprintf(stdout, "%*s%s\n", (int)pad + 2, "", options->help);
 	}
 
 	// print epilog

--- a/lib/nb_smu_ops.c
+++ b/lib/nb_smu_ops.c
@@ -60,7 +60,7 @@ smu_t get_smu(nb_t nb, int smu_type) {
 			smu->arg_base = PSMU_C2PMSG_ARG_BASE;
 			break;
 		default:
-			DBG("Failed to get SMU, unknown SMU_TYPE: %s\n", smu_type);
+			DBG("Failed to get SMU, unknown SMU_TYPE: %i\n", smu_type);
 			goto err;
 			break;
 	}
@@ -69,7 +69,7 @@ smu_t get_smu(nb_t nb, int smu_type) {
 	if(rep == REP_MSG_OK){
 		return smu;
 	} else {
-		DBG("Faild to get SMU: %s, test message REP: %x\n", smu_type, rep);
+		DBG("Faild to get SMU: %i, test message REP: %x\n", smu_type, rep);
 		goto err;
 	}
 err:

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -17,7 +17,11 @@ typedef uint8_t u8;
 typedef uint16_t u16;
 typedef uint64_t u64;
 
+#ifdef NDEBUG
 #define DBG(...)
+#else
+#define DBG(...) fprintf(stderr, __VA_ARGS__)
+#endif
 
 #define AMD_VENDOR_ID 0x1022
 #define NB_DEVICE_ID 0x15d0


### PR DESCRIPTION
warnings and errors get visible inline at github diff view
fix small arg parse warnings

This makes work so much more easy. 
And the Linux build is much faster.

Source of this idea was the need to test if Linux build is still working

I did create this 2nd pull request to change from 2 yaml files to one, because I like the result screen of the combined structure much better https://github.com/Falcosc/RyzenAdj/actions/runs/615639749

TODOs
- [x] add windows debug build
- [x] put arg parse warnings into separate commit