### PR TITLE
Improve SMU initalisation test and add error messages accordingly

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -30,11 +30,13 @@ EXP ryzen_access CALL init_ryzenadj()
 
 	ry->mp1_smu = get_smu(ry->nb, TYPE_MP1);
 	if(!ry->mp1_smu){
+		printf("Unable to get MP1 SMU Obj\n");
 		goto out_free_nb;
 	}
 
 	ry->psmu = get_smu(ry->nb, TYPE_PSMU);
 	if(!ry->psmu){
+		printf("Unable to get RSMU Obj\n");
 		goto out_free_mp1_smu;
 	}
 

--- a/lib/libpci.c
+++ b/lib/libpci.c
@@ -8,6 +8,11 @@ pci_obj_t init_pci_obj(){
 	pci_obj_t obj;
 	obj = pci_alloc();
 	pci_init(obj);
+	if(!obj->writeable)
+	{
+		printf("PCI Bus is not writeable, check secure boot\n");
+		return NULL;
+	}
 	return obj;
 }
 

--- a/lib/nb_smu_ops.c
+++ b/lib/nb_smu_ops.c
@@ -43,7 +43,7 @@ u32 smu_service_req(smu_t smu ,u32 id ,smu_service_args_t *args)
 smu_t get_smu(nb_t nb, int smu_type) {
 	smu_t smu;
 	uint32_t rep; /* REP of test message */
-	smu_service_args_t arg = {0, 0, 0, 0, 0, 0}; /* Test message shuld have no arguments */
+	smu_service_args_t arg = {47, 0, 0, 0, 0, 0}; /* use a unique value to test if write argument does work */
 
 	smu = (smu_t)malloc((sizeof(*smu)));
 	smu->nb = nb;
@@ -64,9 +64,10 @@ smu_t get_smu(nb_t nb, int smu_type) {
 			goto err;
 			break;
 	}
-	/* Try to send a test message*/
+	/* Try to send a test message */
 	rep = smu_service_req(smu, SMU_TEST_MSG, &arg);
-	if(rep == REP_MSG_OK){
+	/* SMUs after early Raven will increment arg0*/
+	if(rep == REP_MSG_OK && (arg.arg0 == 48 || arg.arg0 == 47)){
 		return smu;
 	} else {
 		DBG("Faild to get SMU: %i, test message REP: %x\n", smu_type, rep);


### PR DESCRIPTION
resolves #81

This does avoid sending error message "Not a Ryzen NB SMU, BIOS Interface Ver: 0x1"

I hope all SMUs do increment the first argument during message test.
Renoir does work fine.