### PR TITLE
Move permission error message to the first permission related point o…

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -18,7 +18,7 @@ EXP ryzen_access CALL init_ryzenadj()
 
 	ry->pci_obj = init_pci_obj();
 	if(!ry->pci_obj){
-		printf("Unable to get PCI Obj\n");
+		printf("Unable to get PCI Obj, check permission\n");
 		return NULL;
 	}
 

--- a/main.c
+++ b/main.c
@@ -119,7 +119,7 @@ int main(int argc, const char **argv)
 	//init RyzenAdj and validate that it was able to
 	ry = init_ryzenadj();
 	if(!ry){
-		printf("Unable to init ryzenadj, check permission\n");
+		printf("Unable to init ryzenadj\n");
 		return -1;
 	}
 


### PR DESCRIPTION
…f failure, because permissions are not an fix for secure boot issues