### PR TITLE
Add Windows Powershell script to regularly adjust settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,11 @@ jobs:
             Write-Error "$cmdDemoOutput"
             exit 1
         }
+        $psServiceOutput = Powershell .\readjustService.ps1 -noGUI
+        if ($psServiceOutput -ne $expectedOutput){
+            Write-Error "$psServiceOutput"
+            exit 1
+        }
         exit 0
 
     - name: Upload ryzenadj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: ryzenadj-win64-debug
-        path: |
-            ./debug/ryzenadj.exe
-            ./prebuilt/WinRing0x64.dll
-            ./prebuilt/WinRing0x64.sys
-            ./prebuilt/demo.bat
+        path: ./debug/ryzenadj.exe
 
     - name: Build Release
       run: |
@@ -41,15 +37,32 @@ jobs:
         cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..
         nmake
 
+    - name: Prepair Release Folder
+      run: |
+        mkdir release
+        copy build/ryzenadj.exe release/
+        copy build/libryzenadj.dll release/
+        copy prebuilt/WinRing0x64.dll release/
+        copy prebuilt/WinRing0x64.sys release/
+        copy scripts/* release/
+
+    - name: Test Scripts
+      shell: pwsh
+      run: |
+        cd release
+        $expectedOutput = "Not AMD processor, must be kidding"
+        $cmdDemoOutput = '' | cmd.exe /c .\demo.bat
+        if ($cmdDemoOutput -notcontains $expectedOutput){
+            Write-Error "$cmdDemoOutput"
+            exit 1
+        }
+        exit 0
+
     - name: Upload ryzenadj
       uses: actions/upload-artifact@v2
       with:
         name: ryzenadj-win64
-        path: |
-            ./build/ryzenadj.exe
-            ./prebuilt/WinRing0x64.dll
-            ./prebuilt/WinRing0x64.sys
-            ./prebuilt/demo.bat
+        path: ./release
 
     - name: Upload libryzenadj
       uses: actions/upload-artifact@v2

--- a/prebuilt/demo.bat
+++ b/prebuilt/demo.bat
@@ -1,2 +1,0 @@
-%~dp0\ryzenadj.exe --stapm-limit=40000 --fast-limit=45000 --slow-limit=45000 --tctl-temp=90
-pause

--- a/scripts/RyzenAdjServiceTask.xml.template
+++ b/scripts/RyzenAdjServiceTask.xml.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers>
+    <BootTrigger>
+      <Enabled>true</Enabled>
+    </BootTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+    <RestartOnFailure>
+      <Interval>PT60M</Interval>
+      <Count>10</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell</Command>
+      <Arguments>-WindowStyle hidden -ExecutionPolicy Bypass -file "###SCRIPTPATH###"</Arguments>
+    </Exec>
+  </Actions>
+</Task>

--- a/scripts/demo.bat
+++ b/scripts/demo.bat
@@ -1,0 +1,2 @@
+%~dp0\ryzenadj.exe --stapm-limit=40000 --fast-limit=45000 --slow-limit=45000 --tctl-temp=90
+pause

--- a/scripts/installServiceTask.bat
+++ b/scripts/installServiceTask.bat
@@ -1,0 +1,39 @@
+@echo off
+NET FILE 1>NUL 2>NUL
+if %errorlevel% NEQ 0 (
+	echo Installation need be run as Administrator to install a Task
+	pause
+	exit /B 0
+)
+
+cd /D "%~dp0" 
+choice /C YN /M "Do you want to install Service based on directory %~dp0? It can not be changed after installation."
+if %ERRORLEVEL% NEQ 1 exit /B 1
+
+for %%f in (RyzenAdjServiceTask.xml.template readjustService.ps1 libryzenadj.dll WinRing0x64.dll WinRing0x64.sys inpoutx64.dll) do (
+   if not exist %%f echo %%f is missing && goto failed
+)
+
+echo Please configure RyzenAdjService by adding your prefered values in the top section of the powershell script. 
+timeout /t 2 > NUL
+notepad "%~dp0\readjustService.ps1"
+
+powershell -Command "(gc %~dp0RyzenAdjServiceTask.xml.template) -replace '###SCRIPTPATH###', '%~dp0readjustService.ps1' | Out-File -encoding ASCII %~dp0RyzenAdjServiceTask.xml"
+
+SCHTASKS /Create /TN "AMD\RyzenAdj" /XML "%~dp0RyzenAdjServiceTask.xml" /F || goto failed
+
+SCHTASKS /run /TN "AMD\RyzenAdj" || goto failed
+
+timeout /t 2 > NUL
+
+SCHTASKS /query /TN "AMD\RyzenAdj" || goto failed
+
+echo.
+echo Installation successfull
+pause
+exit /B 0
+
+:FAILED
+echo Installation failed
+pause
+exit /B 1

--- a/scripts/readjustService.ps1
+++ b/scripts/readjustService.ps1
@@ -1,0 +1,169 @@
+Param([Parameter(Mandatory=$false)][switch]$noGUI)
+
+#### Configuration Start
+
+$pathToRyzenAdjDlls = Split-Path -Parent $PSCommandPath #script path is DLL path, needs to be absolut path if you define something else
+
+$showErrorPopupsDuringInit = $true
+
+$debugMode = $false                      #prints adjust success messages too instead of errorss only
+
+function doAdjust_ACmode {
+    adjust "fast_limit" 45000
+    adjust "slow_limit" 25000
+    #adjust "slow_time" 30
+    #adjust "tctl_temp" 97
+    #adjust "apu_skin_temp_limit" 50
+    #adjust "vrmmax_current" 100000
+    $Script:repeatWaitTimeSeconds = 3    #reapplies setting every 3s
+}
+
+function doAdjust_BatteryMode {
+    adjust "fast_limit" 25000
+    adjust "slow_limit" 10000
+    $Script:repeatWaitTimeSeconds = 30   #do less reapplies to save power
+}
+
+#### Configuration End
+################################################################################
+
+$env:PATH += ";$pathToRyzenAdjDlls"
+$NL = $([System.Environment]::NewLine);
+
+if($noGUI){ $showErrorPopupsDuringInit = $false }
+
+$apiHeader = @'
+[DllImport("libryzenadj.dll")] public static extern IntPtr init_ryzenadj();
+[DllImport("libryzenadj.dll")] public static extern int set_stapm_limit(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_fast_limit(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_slow_limit(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_slow_time(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_stapm_time(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_tctl_temp(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_vrm_current(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_vrmsoc_current(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_vrmmax_current(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_vrmsocmax_current(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_psi0_current(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_psi0soc_current(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_max_gfxclk_freq(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_min_gfxclk_freq(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_max_socclk_freq(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_min_socclk_freq(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_max_fclk_freq(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_min_fclk_freq(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_max_vcn(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_min_vcn(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_max_lclk(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_min_lclk(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_prochot_deassertion_ramp(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_apu_skin_temp_limit(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_dgpu_skin_temp_limit(IntPtr ry, uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_apu_slow_limit(IntPtr ry, uint value);
+
+[DllImport("kernel32.dll")] public static extern uint GetModuleFileName(IntPtr hModule, [Out]StringBuilder lpFilename, [In]int nSize);
+
+public static String getExpectedWinRing0DriverFilepath(){
+    StringBuilder fileName = new StringBuilder(255);
+    GetModuleFileName(IntPtr.Zero, fileName, fileName.Capacity);
+    return Path.GetDirectoryName(fileName.ToString()) + "\\WinRing0x64.sys";
+}
+
+public static String getDllImportErrors(){
+    try {
+        Marshal.PrelinkAll(typeof(adj));
+    } catch (Exception e) {
+        return e.Message;
+    }
+    return "";
+}
+'@
+
+if(-not ([System.Management.Automation.PSTypeName]'ryzen.adj').Type){
+    Add-Type -MemberDefinition $apiHeader -Namespace 'ryzen' -Name 'adj' -UsingNamespace ('System.Text', 'System.IO')
+}
+
+Add-Type -AssemblyName System.Windows.Forms
+function showErrorMsg ([String] $msg){
+    if($showErrorPopupsDuringInit){
+        $res = [System.Windows.Forms.MessageBox]::Show($msg, $PSCommandPath,
+        [System.Windows.Forms.MessageBoxButtons]::OK,
+        [System.Windows.Forms.MessageBoxIcon]::Error)
+    }
+}
+
+$dllImportErrors = [ryzen.adj]::getDllImportErrors();
+if($dllImportErrors -or $Error){
+    Write-Error $dllImportErrors
+    showErrorMsg "Problem with using libryzenadj.dll$NL$NL$Error"
+    exit 1
+}
+
+$winring0DriverFilepath = [ryzen.adj]::getExpectedWinRing0DriverFilepath()
+if(!(Test-Path $winring0DriverFilepath)) { Copy-Item -Path $pathToRyzenAdjDlls\WinRing0x64.sys -Destination $winring0DriverFilepath }
+
+$ry = [ryzen.adj]::init_ryzenadj()
+if($ry -eq 0){
+    $msg = "RyzenAdj could not get initialized.$($NL)Reason can be found inside Powershell$($NL)"
+    if($psISE) { $msg += "It is not possible to see the error reason inside ISE, you need to test it in PowerShell Console" }
+    showErrorMsg "$msg$NL$NL$Error"
+    exit 1
+}
+
+function adjust ([String] $fieldName, [uInt32] $value) {
+    $res = Invoke-Expression "[ryzen.adj]::set_$fieldName($ry, $value)"
+    switch ($res)
+    {
+        0 {
+            if($debugMode) { Write-Host "set $fieldName to $value" }
+            return
+        }
+        -1 { Write-Error "set_$fieldName is not supported on this family"}
+        -3 { Write-Error "set_$fieldName is not supported on this SMU"}
+        -4 { Write-Error "set_$fieldName is rejected by SMU"}
+        default { Write-Error "set_$fieldName did fail with $res"}
+    }
+}
+
+function testAdjustments {
+    Write-Host "Test Adjustments"
+    $batteryStatus=(Get-WmiObject -Class BatteryStatus -Namespace root\wmi -ErrorAction Ignore)
+    if($batteryStatus){
+        $isDesktop = $false;
+        if($batteryStatus.PowerOnLine){
+            doAdjust_BatteryMode
+            doAdjust_ACmode
+        } else {
+            doAdjust_ACmode
+            doAdjust_BatteryMode
+        }
+    } else {
+        $isDesktop = $true;
+        Write-Host "Device has no battery, doAdjust_BatteryMode will be ignored"
+        doAdjust_ACmode
+    }
+    if($Error -and $showErrorPopupsDuringInit){
+        $answer = [System.Windows.Forms.MessageBox]::Show("Your Adjustment configuration did not work.$NL$NL$Error", $PSCommandPath,
+            [System.Windows.Forms.MessageBoxButtons]::AbortRetryIgnore,
+            [System.Windows.Forms.MessageBoxIcon]::Warning)
+        $Error.Clear()
+        if($answer -eq "Abort"){ exit 1 }
+        if($answer -eq "Retry"){ testAdjustments }
+    }
+}
+
+if(-not $Script:repeatWaitTimeSeconds) { $Script:repeatWaitTimeSeconds = 5 }
+
+testAdjustments
+
+Write-Host "Apply settings every $Script:repeatWaitTimeSeconds seconds..."
+while($true) {
+    $oldWait = $Script:repeatWaitTimeSeconds
+    if($isDesktop -or (Get-WmiObject -Class BatteryStatus -Namespace root\wmi).PowerOnLine){
+        doAdjust_ACmode
+    } else {
+        doAdjust_BatteryMode
+    }
+    if($oldWait -ne $Script:repeatWaitTimeSeconds ) { Write-Host "Apply settings every $Script:repeatWaitTimeSeconds seconds..." }
+    sleep $Script:repeatWaitTimeSeconds
+}

--- a/scripts/uninstallServiceTask.bat
+++ b/scripts/uninstallServiceTask.bat
@@ -1,0 +1,23 @@
+@echo off
+NET FILE 1>NUL 2>NUL
+if %errorlevel% NEQ 0 (
+	echo Deinstallation need to be run as Administrator to delete your Scheduled Task
+	pause
+	exit /B 0
+)
+
+SCHTASKS /query /TN "AMD\RyzenAdj" 2>NUL
+
+if %errorlevel% NEQ 0 (
+	echo RyzenAdj Service Task is not installed
+	pause
+	exit /B 0
+)
+
+:delete
+SCHTASKS /delete /TN "AMD\RyzenAdj" 2>NUL
+
+if %errorlevel% NEQ 0 goto delete
+
+pause
+exit /B 0


### PR DESCRIPTION
After the PTable Merge, the Powershell script will get much more advanced, with configuration for wait time,  battery check and key benefit: checking one configurable parameter for monitoring if a setting needs to be adjusted.

But to get this we need a new release Build structure where users don't need to copy things around and we need the lib dll in the release for the scripts. If you just want to merge the new release structure: https://github.com/FlyGoat/RyzenAdj/pull/109

I will create a python script for Linux after the powershell script is done and ptable support for linux is done.

I did also introduce a very basic script test step where we just check if the scripts still align to our API, just in case somebody did forget to update them after an API change.