### PR TITLE
Fix missing error Message Boxes during Boot

### DIFF
--- a/scripts/RyzenAdjServiceTask.xml.template
+++ b/scripts/RyzenAdjServiceTask.xml.template
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <Triggers>
-    <BootTrigger>
+    <LogonTrigger>
       <Enabled>true</Enabled>
-    </BootTrigger>
+    </LogonTrigger>
   </Triggers>
   <Principals>
     <Principal id="Author">


### PR DESCRIPTION
 Change Powershell Task from Boot to Logon to be able to display init error messages

 Reduce Powershell complexity and add some micro improvements for efficiency

