### PR TITLE
Print help if no args or non option args are used

### DIFF
--- a/argparse.c
+++ b/argparse.c
@@ -272,6 +272,9 @@ argparse_parse(struct argparse *self, int argc, const char **argv)
 			if (self->flags & ARGPARSE_STOP_AT_NON_OPTION) {
 				goto end;
 			}
+			if (self->flags & ARGPARSE_NON_OPTION_IS_INVALID) {
+				goto unknown;
+			}
 			// if it's not option or is a single char '-', copy verbatim
 			self->out[self->cpidx++] = self->argv[0];
 			continue;

--- a/argparse.c
+++ b/argparse.c
@@ -265,6 +265,10 @@ argparse_parse(struct argparse *self, int argc, const char **argv)
 	self->out  = argv;
 
 	argparse_options_check(self->options);
+	if(!self->argc) {
+		argparse_usage(self);
+		exit(1);
+	}
 
 	for (; self->argc; self->argc--, self->argv++) {
 		const char *arg = self->argv[0];

--- a/argparse.h
+++ b/argparse.h
@@ -23,6 +23,7 @@ typedef int argparse_callback (struct argparse *self,
 
 enum argparse_flag {
 	ARGPARSE_STOP_AT_NON_OPTION = 1,
+	ARGPARSE_NON_OPTION_IS_INVALID = 2,
 };
 
 enum argparse_option_type {

--- a/main.c
+++ b/main.c
@@ -111,7 +111,7 @@ int main(int argc, const char **argv)
 
 
 	struct argparse argparse;
-	argparse_init(&argparse, options, usage, 0);
+	argparse_init(&argparse, options, usage, ARGPARSE_NON_OPTION_IS_INVALID);
 	argparse_describe(&argparse, "\n Ryzen Power Management adjust tool.", "\nWARNING: Use at your own risk!\nBy Jiaxun Yang <jiaxun.yang@flygoat.com>, Under LGPL.\nVersion: v" STRINGIFY(RYZENADJ_REVISION_VER) "." STRINGIFY(RYZENADJ_MAJOR_VER) "." STRINGIFY(RYZENADJ_MINIOR_VER));
 	argc = argparse_parse(&argparse, argc, argv);
 


### PR DESCRIPTION
But it is still possible to use the separator
```
ryzenadj --
```
all other noop arguments will now print help