### PR TITLE
Build cleanup, use latest Ubuntu and fix apt-get install issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,13 +84,15 @@ jobs:
             ./win32/WinRing0x64.sys
 
   Linux:
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install Dependencies
-      run: sudo apt install libpci-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libpci-dev
 
     - name: run-cmake
       uses: lukka/run-cmake@v3.3


### PR DESCRIPTION
fix apt-get install issues

```
0 upgraded, 2 newly installed, 0 to remove and 8 not upgraded.
Need to get 66.2 kB of archives.
After this operation, 493 kB of additional disk space will be used.
Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libudev-dev amd64 245.4-4ubuntu3.4
  404  Not Found [IP: 52.154.174.208 80]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libpci-dev amd64 1:3.6.4-1 [46.5 kB]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_245.4-4ubuntu3.4_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
Fetched 46.5 kB in 0s (419 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```