### PR TITLE
Add Release build type to documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ PROJECT(ryzenadj)
 
 set(CMAKE_CXX_STANDARD 11)
 
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 INCLUDE_DIRECTORIES(${INC_DIR})
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ sudo dnf install pciutils-devel
 The simplest way to build it:
 
     mkdir build && cd build
-    cmake ..
+    cmake -DCMAKE_BUILD_TYPE=Release ..
     make
 
 ### Windows


### PR DESCRIPTION
@ericonr you may want to check if your Void Linux package configuration does create a Release build because default cmake does create debug builds.

@delbato please check your arch Linux build configuration

Some weeks ago we did add more messages for debug builds, now it's very easy to see if you did create a debug build accidentally.