### PR TITLE
Interface Change: PTable Support - Version B

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Usage: ryzenadj [options] [[--] args]
     -h, --help                            show this help message and exit
 
 Options
-    -i, --info                            Show information (W.I.P.)
+    -i, --info                            Show information and most importand power metrics after adjustment
+    --dump-table                          Show whole power metric table before and after adjustment
 
 Settings
     -a, --stapm-limit=<u32>               Sustained Power Limit         - STAPM LIMIT (mW)

--- a/lib/api.c
+++ b/lib/api.c
@@ -3,6 +3,7 @@
 /* RyzenAdj API */
 
 #include "ryzenadj.h"
+#include "math.h"
 
 EXP ryzen_access CALL init_ryzenadj()
 {
@@ -14,8 +15,9 @@ EXP ryzen_access CALL init_ryzenadj()
 	ry = (ryzen_access)malloc((sizeof(*ry)));
 
 	ry->family = family;
-	//init version only on demand to avoid unnecessary SMU writes
+	//init version and power metric table only on demand to avoid unnecessary SMU writes
 	ry->bios_if_ver = 0;
+	ry->table_values = NULL;
 
 	ry->pci_obj = init_pci_obj();
 	if(!ry->pci_obj){
@@ -57,6 +59,7 @@ EXP void CALL cleanup_ryzenadj(ryzen_access ry){
 	if (ry == NULL)
 	    return;
 
+	free_mem_obj(ry->mem_obj);
 	free_smu(ry->psmu);
 	free_smu(ry->mp1_smu);
 	free_nb(ry->nb);
@@ -80,6 +83,233 @@ EXP int get_bios_if_ver(ryzen_access ry)
 	return ry->bios_if_ver;
 }
 
+#define _return_translated_smu_error(SMU_RESP)         \
+do {                                                   \
+	if (SMU_RESP == REP_MSG_UnknownCmd) {              \
+		printf("%s is unsupported\n", __func__);       \
+		return ADJ_ERR_SMU_UNSUPPORTED;                \
+	} else if (SMU_RESP == REP_MSG_CmdRejectedPrereq){ \
+		printf("%s was rejected\n", __func__);         \
+		return ADJ_ERR_SMU_REJECTED;                   \
+	} else if (SMU_RESP == REP_MSG_CmdRejectedBusy) {  \
+		printf("%s was rejected - busy\n", __func__);  \
+		return ADJ_ERR_SMU_REJECTED;                   \
+	} else {                                           \
+		printf("%s failed\n", __func__);               \
+		return ADJ_ERR_SMU_REJECTED;                   \
+	}                                                  \
+} while (0);
+
+int request_table_ver_and_size(ryzen_access ry)
+{
+	unsigned int get_table_ver_msg;
+	int resp;
+	switch (ry->family)
+	{
+	case FAM_RAVEN:
+	case FAM_PICASSO:
+		get_table_ver_msg = 0xC;
+		break;
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+		get_table_ver_msg = 0x6;
+		break;
+	default:
+		printf("request_table_ver_and_size is not supported on this family\n");
+		return ADJ_ERR_FAM_UNSUPPORTED;
+	}
+
+	smu_service_args_t args = {0, 0, 0, 0, 0, 0};
+	resp = smu_service_req(ry->psmu, get_table_ver_msg, &args);
+	ry->table_ver = args.arg0;
+
+	switch (ry->table_ver)
+	{
+		case 0x1E0004: ry->table_size = 0x6AC; break;
+		case 0x1E0005: ry->table_size = 0x6AC; break;
+		case 0x1E0101: ry->table_size = 0x6AC; break;
+		case 0x240802: ry->table_size = 0x7E0; break;
+		case 0x240803: ry->table_size = 0x7E4; break;
+		case 0x240902: ry->table_size = 0x514; break;
+		case 0x240903: ry->table_size = 0x518; break;
+		case 0x2D0803: ry->table_size = 0x894; break;
+		case 0x380804: ry->table_size = 0x8A4; break;
+		case 0x2D0903: ry->table_size = 0x594; break;
+		case 0x380904: ry->table_size = 0x5A4; break;
+		case 0x370000: ry->table_size = 0x794; break;
+		case 0x370001: ry->table_size = 0x884; break;
+		case 0x370002: ry->table_size = 0x88C; break;
+		case 0x370003: ry->table_size = 0x8AC; break;
+		case 0x370004: ry->table_size = 0x8AC; break;
+		case 0x370005: ry->table_size = 0x8C8; break;
+		default:
+			//use smallest size for unknown version to support dump of unknown tables
+			ry->table_size = 0x514;
+	}
+
+	if (resp != REP_MSG_OK) {
+		_return_translated_smu_error(resp);
+	}
+	if(!ry->table_ver){
+		printf("request_table_ver_and_size did not return anything\n");
+		return ADJ_ERR_SMU_UNSUPPORTED;
+	}
+	return 0;
+}
+
+int request_table_addr(ryzen_access ry)
+{
+	unsigned int get_table_addr_msg;
+	int resp;
+	smu_service_args_t args = {0, 0, 0, 0, 0, 0};
+	switch (ry->family)
+	{
+	case FAM_RAVEN:
+	case FAM_PICASSO:
+		args.arg0 = 3;
+		get_table_addr_msg = 0xB;
+		break;
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+		get_table_addr_msg = 0x66;
+		break;
+	default:
+		printf("request_table_addr is not supported on this family\n");
+		return ADJ_ERR_FAM_UNSUPPORTED;
+	}
+
+	resp = smu_service_req(ry->psmu, get_table_addr_msg, &args);
+	ry->table_addr = args.arg0;
+	if(resp != REP_MSG_OK){
+		_return_translated_smu_error(resp);
+	}
+	if(!ry->table_addr){
+		printf("request_table_addr did not return anything\n");
+		return ADJ_ERR_SMU_UNSUPPORTED;
+	}
+	return 0;
+}
+
+int request_transfer_table(ryzen_access ry)
+{
+	int resp;
+	unsigned int transfer_table_msg;
+	smu_service_args_t args = {0, 0, 0, 0, 0, 0};
+	switch (ry->family)
+	{
+	case FAM_RAVEN:
+	case FAM_PICASSO:
+		args.arg0 = 3;
+		transfer_table_msg = 0x3D;
+		break;
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+		transfer_table_msg = 0x65;
+		break;
+	default:
+		printf("request_transfer_table is not supported on this family\n");
+		return ADJ_ERR_FAM_UNSUPPORTED;
+	}
+
+	resp = smu_service_req(ry->psmu, transfer_table_msg, &args);
+	if(resp != REP_MSG_OK){
+		_return_translated_smu_error(resp);
+	}
+	return 0;
+}
+
+EXP int CALL init_table(ryzen_access ry)
+{
+	DBG("init_table\n");
+	int errorcode = 0;
+
+	errorcode = request_table_ver_and_size(ry);
+	if(errorcode){
+		return errorcode;
+	}
+
+	errorcode = request_table_addr(ry);
+	if(errorcode){
+		return errorcode;
+	}
+
+	//init memory object because it is prerequiremt to woring with physical memory address
+	ry->mem_obj = init_mem_obj();
+	if(!ry->mem_obj)
+	{
+		printf("Unable to get MEM Obj\n");
+		return ADJ_ERR_MEMORY_ACCESS;
+	}
+
+	//hold copy of table value in memory for our single value getters
+	ry->table_values = malloc(ry->table_size);
+
+	errorcode = refresh_table(ry);
+	if(errorcode)
+	{
+		return errorcode;
+	}
+
+	if(!ry->table_values[0]){
+		//Raven and Picasso don't get table refresh on the very first transfer call after boot, but respond with OK
+		//if we detact 0 data, do an initial 2nd call after a small delay (copy_from_phyaddr is enough delay)
+		//transfer, transfer, wait, wait longer; don't work
+		//transfer, wait, wait longer; don't work
+		//transfer, wait, transfer; does work
+		return refresh_table(ry);
+	}
+
+	return 0;
+}
+
+#define _lazy_init_table(RETURN_VAR)                                 \
+do {                                                                 \
+	if(!ry->table_values) {                                          \
+		DBG("warning: %s was called before init_table\n", __func__); \
+		errorcode = init_table(ry);                                  \
+		if(errorcode) return RETURN_VAR;                             \
+	}                                                                \
+} while (0);
+
+EXP uint32_t CALL get_table_ver(ryzen_access ry)
+{
+	int errorcode;
+	_lazy_init_table(0);
+
+	return ry->table_ver;
+}
+
+EXP size_t CALL get_table_size(ryzen_access ry)
+{
+	int errorcode;
+	_lazy_init_table(0);
+
+	return ry->table_size;
+}
+
+EXP float* CALL get_table_values(ryzen_access ry)
+{
+	return ry->table_values;
+}
+
+EXP int CALL refresh_table(ryzen_access ry)
+{
+	int errorcode;
+	_lazy_init_table(errorcode);
+
+	errorcode = request_transfer_table(ry);
+	if(errorcode){
+		return errorcode;
+	}
+
+	if(copy_from_phyaddr(ry->table_addr, ry->table_values, ry->table_size)){
+		printf("refresh_table failed\n");
+		return ADJ_ERR_MEMORY_ACCESS;
+	}
+
+	return 0;
+}
+
 #define _do_adjust(OPT) \
 do {                                                 \
 	smu_service_args_t args = {0, 0, 0, 0, 0, 0};    \
@@ -95,7 +325,16 @@ do {                                                 \
 	}                                                \
 } while (0);
 
-
+#define _read_float_value(OFFSET)                   \
+do {                                                \
+	uint32_t addr;                                  \
+	float value;                                    \
+	addr = get_table_addr(ry);                      \
+	if(!addr)                                       \
+		return NAN;                                 \
+	copy_from_phyaddr(addr + OFFSET, &value, 4);    \
+	return value;                                   \
+} while (0);
 
 EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){
 	switch (ry->family)
@@ -475,3 +714,70 @@ EXP int CALL set_skin_temp_power_limit(ryzen_access ry, uint32_t value) {
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
+
+//PM Table section, offset of first lines are stable across multiple PM Table versions
+EXP float CALL get_stapm_limit(ryzen_access ry){_read_float_value(0x0);}
+EXP float CALL get_stapm_value(ryzen_access ry){_read_float_value(0x4);}
+EXP float CALL get_fast_limit(ryzen_access ry){_read_float_value(0x8);}
+EXP float CALL get_fast_value(ryzen_access ry){_read_float_value(0xC);}
+EXP float CALL get_slow_limit(ryzen_access ry){_read_float_value(0x10);}
+EXP float CALL get_slow_value(ryzen_access ry){_read_float_value(0x14);}
+EXP float CALL get_apu_slow_limit(ryzen_access ry){_read_float_value(0x18);}
+EXP float CALL get_apu_slow_value(ryzen_access ry){_read_float_value(0x1C);}
+EXP float CALL get_vrm_current(ryzen_access ry){_read_float_value(0x20);}
+EXP float CALL get_vrm_current_value(ryzen_access ry){_read_float_value(0x24);}
+EXP float CALL get_vrmsoc_current(ryzen_access ry){_read_float_value(0x28);}
+EXP float CALL get_vrmsoc_current_value(ryzen_access ry){_read_float_value(0x2C);}
+EXP float CALL get_vrmmax_current(ryzen_access ry){_read_float_value(0x30);}
+EXP float CALL get_vrmmax_current_value(ryzen_access ry){_read_float_value(0x34);}
+EXP float CALL get_vrmsocmax_current(ryzen_access ry){_read_float_value(0x38);}
+EXP float CALL get_vrmsocmax_current_value(ryzen_access ry){_read_float_value(0x3C);}
+EXP float CALL get_tctl_temp(ryzen_access ry){_read_float_value(0x40);}
+EXP float CALL get_tctl_temp_value(ryzen_access ry){_read_float_value(0x44);}
+//unsed: "THM LIMIT GFX" 0x48
+//unsed: "THM VALUE GFX" 0x4C
+//unsed: "THM LIMIT SOC" 0x50
+//unsed: "THM VALUE SOC" 0x54
+EXP float CALL get_apu_skin_temp_limit(ryzen_access ry){_read_float_value(0x58);}
+EXP float CALL get_apu_skin_temp_value(ryzen_access ry){_read_float_value(0x5C);}
+EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry){_read_float_value(0x60);}
+EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry){_read_float_value(0x64);}
+//unsed: "FIT LIMIT" 0x68
+//unsed: "FIT VALUE" 0x6C
+//unsed: "VID LIMIT" 0x70
+//unsed: "VID VALUE" 0x74
+EXP float CALL get_psi0_current(ryzen_access ry){_read_float_value(0x78);}
+//unsed: "PSI0 RESIDENCY VDD" 0x7C
+EXP float CALL get_psi0soc_current(ryzen_access ry){_read_float_value(0x80);}
+//unsed: "PSI0 RESIDENCY SOC" 0x84
+
+//custom section, offsets are depending on table version
+EXP float CALL get_stapm_time(ryzen_access ry)
+{
+	switch (ry->table_ver)
+	{
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x880);
+	case 0x00370005:
+		_read_float_value(0x89C);
+	}
+	return NAN;
+}
+
+EXP float CALL get_slow_time(ryzen_access ry){
+	switch (ry->table_ver)
+	{
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x884);
+	case 0x00370005:
+		_read_float_value(0x8A0);
+	}
+	return NAN;
+}
+

--- a/lib/api.c
+++ b/lib/api.c
@@ -59,6 +59,9 @@ EXP void CALL cleanup_ryzenadj(ryzen_access ry){
 	if (ry == NULL)
 	    return;
 
+	if (ry->table_values){
+		free(ry->table_values);
+	}
 	free_mem_obj(ry->mem_obj);
 	free_smu(ry->psmu);
 	free_smu(ry->mp1_smu);
@@ -327,13 +330,9 @@ do {                                                 \
 
 #define _read_float_value(OFFSET)                   \
 do {                                                \
-	uint32_t addr;                                  \
-	float value;                                    \
-	addr = get_table_addr(ry);                      \
-	if(!addr)                                       \
+	if(!ry->table_values)                           \
 		return NAN;                                 \
-	copy_from_phyaddr(addr + OFFSET, &value, 4);    \
-	return value;                                   \
+	return ry->table_values[OFFSET / 4];            \
 } while (0);
 
 EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -51,6 +51,7 @@ struct _ryzen_access;
 #define ADJ_ERR_SMU_TIMEOUT          -2
 #define ADJ_ERR_SMU_UNSUPPORTED      -3
 #define ADJ_ERR_SMU_REJECTED         -4
+#define ADJ_ERR_MEMORY_ACCESS        -5
 
 typedef struct _ryzen_access *ryzen_access;
 
@@ -60,6 +61,12 @@ EXP void CALL cleanup_ryzenadj(ryzen_access ry);
 
 EXP enum ryzen_family get_cpu_family(ryzen_access ry);
 EXP int get_bios_if_ver(ryzen_access ry);
+
+EXP int CALL init_table(ryzen_access ry);
+EXP uint32_t CALL get_table_ver(ryzen_access ry);
+EXP size_t CALL get_table_size(ryzen_access ry);
+EXP float* CALL get_table_values(ryzen_access ry);
+EXP int CALL refresh_table(ryzen_access ry);
 
 EXP int CALL set_stapm_limit(ryzen_access, uint32_t value);
 EXP int CALL set_fast_limit(ryzen_access, uint32_t value);
@@ -88,6 +95,33 @@ EXP int CALL set_apu_skin_temp_limit(ryzen_access, uint32_t value);
 EXP int CALL set_dgpu_skin_temp_limit(ryzen_access, uint32_t value);
 EXP int CALL set_apu_slow_limit(ryzen_access, uint32_t value);
 EXP int CALL set_skin_temp_power_limit(ryzen_access ry, uint32_t value);
+
+EXP float CALL get_stapm_limit(ryzen_access ry);
+EXP float CALL get_stapm_value(ryzen_access ry);
+EXP float CALL get_fast_limit(ryzen_access ry);
+EXP float CALL get_fast_value(ryzen_access ry);
+EXP float CALL get_slow_limit(ryzen_access ry);
+EXP float CALL get_slow_value(ryzen_access ry);
+EXP float CALL get_apu_slow_limit(ryzen_access ry);
+EXP float CALL get_apu_slow_value(ryzen_access ry);
+EXP float CALL get_vrm_current(ryzen_access ry);
+EXP float CALL get_vrm_current_value(ryzen_access ry);
+EXP float CALL get_vrmsoc_current(ryzen_access ry);
+EXP float CALL get_vrmsoc_current_value(ryzen_access ry);
+EXP float CALL get_vrmmax_current(ryzen_access ry);
+EXP float CALL get_vrmmax_current_value(ryzen_access ry);
+EXP float CALL get_vrmsocmax_current(ryzen_access ry);
+EXP float CALL get_vrmsocmax_current_value(ryzen_access ry);
+EXP float CALL get_tctl_temp(ryzen_access ry);
+EXP float CALL get_tctl_temp_value(ryzen_access ry);
+EXP float CALL get_apu_skin_temp_limit(ryzen_access ry);
+EXP float CALL get_apu_skin_temp_value(ryzen_access ry);
+EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry);
+EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry);
+EXP float CALL get_psi0_current(ryzen_access ry);
+EXP float CALL get_psi0soc_current(ryzen_access ry);
+EXP float CALL get_stapm_time(ryzen_access ry);
+EXP float CALL get_slow_time(ryzen_access ry);
 
 
 #ifdef __cplusplus

--- a/lib/ryzenadj_priv.h
+++ b/lib/ryzenadj_priv.h
@@ -21,6 +21,9 @@ struct _ryzen_access {
 	smu_t psmu;
 	enum ryzen_family family;
 	int bios_if_ver;
+	uint32_t table_addr;
+	uint32_t table_ver;
+	size_t table_size;
 };
 
 enum ryzen_family cpuid_get_family();

--- a/lib/ryzenadj_priv.h
+++ b/lib/ryzenadj_priv.h
@@ -24,6 +24,7 @@ struct _ryzen_access {
 	uint32_t table_addr;
 	uint32_t table_ver;
 	size_t table_size;
+	float *table_values;
 };
 
 enum ryzen_family cpuid_get_family();


### PR DESCRIPTION
I did refactor by ptable branch

It is simpler with less complexity, has better error management, but it does expose the pointer of our internal ptable copy

```
EXP int CALL init_table(ryzen_access ry);
EXP uint32_t CALL get_table_ver(ryzen_access ry);
EXP size_t CALL get_table_size(ryzen_access ry);
EXP float* CALL get_table_values(ryzen_access ry);
EXP int CALL refresh_table(ryzen_access ry);
```

Exposing the pointer is not a big deal, if somebody does call a free on it, the interface will take care and handle it like user did forget to call `init_table`
So, the new version doesn't have complex checks for the availability of all fields (size, version, addr, table allocation) it just checks if the table is allocated, and if not, it inits the whole table feature.

This branch needs a rebase to remove the history from the first try. So please merge https://github.com/FlyGoat/RyzenAdj/pull/115 first.