### PR TITLE
Allow skipping table transfer (expose internals)

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -273,6 +273,7 @@ EXP int CALL init_table(ryzen_access ry)
 
 	//hold copy of table value in memory for our single value getters
 	ry->table_values = malloc(ry->table_size);
+	ry->skip_table_transfer = false;
 
 	errorcode = refresh_table(ry);
 	if(errorcode)
@@ -327,8 +328,8 @@ EXP int CALL refresh_table(ryzen_access ry)
 	int errorcode = 0;
 	_lazy_init_table(errorcode);
 
-	//only execute request table if we don't use SMU driver
-	if(!is_using_smu_driver()){
+	//only execute request table if we don't use SMU driver and if we don't want to skip transfer
+	if(!is_using_smu_driver() && !ry->skip_table_transfer){
 		errorcode = request_transfer_table(ry);
 	}
 
@@ -342,6 +343,11 @@ EXP int CALL refresh_table(ryzen_access ry)
 	}
 
 	return 0;
+}
+
+EXP void CALL set_skip_table_transfer(ryzen_access ry, bool skip_table_transfer)
+{
+	ry->skip_table_transfer = skip_table_transfer;
 }
 
 #define _do_adjust(OPT) \

--- a/lib/api.c
+++ b/lib/api.c
@@ -264,7 +264,7 @@ EXP int CALL init_table(ryzen_access ry)
 	}
 
 	//init memory object because it is prerequiremt to woring with physical memory address
-	ry->mem_obj = init_mem_obj();
+	ry->mem_obj = init_mem_obj(ry->table_addr);
 	if(!ry->mem_obj)
 	{
 		printf("Unable to get MEM Obj\n");
@@ -332,7 +332,7 @@ EXP int CALL refresh_table(ryzen_access ry)
 		return errorcode;
 	}
 
-	if(copy_from_phyaddr(ry->table_addr, ry->table_values, ry->table_size)){
+	if(copy_from_phyaddr(ry->table_values, ry->table_size)){
 		printf("refresh_table failed\n");
 		return ADJ_ERR_MEMORY_ACCESS;
 	}

--- a/lib/api.c
+++ b/lib/api.c
@@ -324,10 +324,14 @@ EXP float* CALL get_table_values(ryzen_access ry)
 
 EXP int CALL refresh_table(ryzen_access ry)
 {
-	int errorcode;
+	int errorcode = 0;
 	_lazy_init_table(errorcode);
 
-	errorcode = request_transfer_table(ry);
+	//only execute request table if we don't use SMU driver
+	if(!is_using_smu_driver()){
+		errorcode = request_transfer_table(ry);
+	}
+
 	if(errorcode){
 		return errorcode;
 	}

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -106,10 +106,10 @@ smu_t get_smu(nb_t nb, int smu_type);
 void free_smu(smu_t smu);
 u32 smu_service_req(smu_t smu ,u32 id ,smu_service_args_t *args);
 
-mem_obj_t init_mem_obj();
+mem_obj_t init_mem_obj(u32 physAddr);
 
 void free_mem_obj(mem_obj_t obj);
 
-int copy_from_phyaddr(u32 physAddr, void *buffer, size_t size);
+int copy_from_phyaddr(void *buffer, size_t size);
 
 #endif

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -112,4 +112,5 @@ void free_mem_obj(mem_obj_t obj);
 
 int copy_from_phyaddr(void *buffer, size_t size);
 
+bool is_using_smu_driver();
 #endif

--- a/lib/osdep_linux.c
+++ b/lib/osdep_linux.c
@@ -11,7 +11,7 @@
 
 bool mem_obj_obj = true;
 int pm_table_fd = 0;
-int dev_mem_fd = 0;
+void *phy_map = MAP_FAILED;
 
 pci_obj_t init_pci_obj(){
 	pci_obj_t obj;
@@ -48,27 +48,41 @@ void smn_reg_write(nb_t nb, u32 addr, u32 data)
 	pci_write_long(nb, NB_PCI_REG_DATA_ADDR, data);
 }
 
-mem_obj_t init_mem_obj()
+mem_obj_t init_mem_obj(u32 physAddr)
 {
-	int dev_mem_errno, pm_table_errno;
+	int dev_mem_fd; 
+	int dev_mem_errno, mmap_errno;
 
-	//It is to complicated to check PAT, CONFIG_NONPROMISC_DEVMEM, CONFIG_STRICT_DEVMEM or other dependencies, just try to open /dev/mem and try to use it later
+	//It is to complicated to check PAT, CONFIG_NONPROMISC_DEVMEM, CONFIG_STRICT_DEVMEM or other dependencies, just try to open /dev/mem
 	dev_mem_fd = open("/dev/mem", O_RDONLY);
-	if (dev_mem_fd == -1){
-		dev_mem_errno = errno;
+	dev_mem_errno = errno;
+	if (dev_mem_fd > 0){
+		phy_map = mmap(NULL, 0x1000, PROT_READ, MAP_SHARED, dev_mem_fd, physAddr);
+		mmap_errno = errno;
+		close(dev_mem_fd);
 	}
 
-	pm_table_fd = open("/sys/kernel/ryzen_smu_drv/pm_table", O_RDONLY);
-	if (pm_table_fd == -1){
-		pm_table_errno = errno;
-	}
+	if(phy_map == MAP_FAILED){
+		//only complain about mmap errors if we don't have access to alternative smu driver
+		pm_table_fd = open("/sys/kernel/ryzen_smu_drv/pm_table", O_RDONLY);
+		if (pm_table_fd < 0) {
+			printf("failed to get /sys/kernel/ryzen_smu_drv/pm_table: %s\n", strerror(errno));
 
-	if(dev_mem_fd == -1 && dev_mem_fd -1){
-		printf("failed to get /dev/mem: %s\n", strerror(dev_mem_errno));
-		printf("failed to get /sys/kernel/ryzen_smu_drv/pm_table: %s\n", strerror(pm_table_errno));
-		printf("If you don't want to change your memory access policy, you need a kernel module for this task.\n");
-		printf("We do support usage of this kernel module https://gitlab.com/leogx9r/ryzen_smu\n");
-		return NULL;
+			//show either fd error or mmap error, depending on which was the problem
+			if(dev_mem_errno) {
+				printf("failed to get /dev/mem: %s\n", strerror(dev_mem_errno));
+			} else {
+				printf("failed to map /dev/mem: %s\n", strerror(mmap_errno));
+			}
+
+			if(mmap_errno == EPERM || dev_mem_fd < 0) {
+				//we are already superuser if memory access is requested because we did successfully do the other smu calls.
+				//missing /dev/mem or missing permissions can only mean memory access policy
+				printf("If you don't want to change your memory access policy, you need a kernel module for this task.\n");
+				printf("We do support usage of this kernel module https://gitlab.com/leogx9r/ryzen_smu\n");
+			}
+			return NULL;
+		}
 	}
 
 	return &mem_obj_obj;
@@ -76,8 +90,8 @@ mem_obj_t init_mem_obj()
 
 void free_mem_obj(mem_obj_t obj)
 {
-	if(dev_mem_fd > 0) {
-		close(dev_mem_fd);
+	if(phy_map != MAP_FAILED){
+		munmap(phy_map, 0x1000);
 	}
 	if(pm_table_fd > 0) {
 		close(pm_table_fd);
@@ -85,39 +99,30 @@ void free_mem_obj(mem_obj_t obj)
 	return;
 }
 
-int copy_from_phyaddr(u32 physAddr, void *buffer, size_t size)
+int copy_from_phyaddr(void *buffer, size_t size)
 {
-	void *phy_map;
-	int read_size, last_errno;
+	int read_size;
 
-	//use ryzen_smu kernel modul for pm table if existing
 	if(pm_table_fd > 0){
 		lseek(pm_table_fd, 0, SEEK_SET);
 		read_size = read(pm_table_fd, buffer, size);
 		if(read_size == -1) {
 			printf("failed to get pm_table from ryzen_smu kernel module: %s\n", strerror(errno));
-		} else {
-			return 0;
+			return -1;
 		}
+		return 0;
 	}
 
-	//use /dev/mem if ryzen_smu kernel module is not installed or if it did fail
-	if(dev_mem_fd > 0) {
-		phy_map = mmap(NULL, size, PROT_READ, MAP_SHARED, dev_mem_fd, physAddr);
-		if (phy_map == MAP_FAILED) {
-			last_errno = errno;
-			printf("failed to map /dev/mem: %s\n", strerror(last_errno));
-			if(last_errno == EPERM) {
-				//we are already superuser if memory access is requested because we did successfully do the other smu calls
-				printf("If you don't want to change your memory access policy, you need a kernel module for this task.\n");
-				printf("We do support usage of this kernel module https://gitlab.com/leogx9r/ryzen_smu\n");
-			}
-		} else {
-			memcpy(buffer, phy_map, size);
-			munmap(phy_map, size);
-			return 0;
-		}
+	if(phy_map != MAP_FAILED){
+		memcpy(buffer, phy_map, size);
+		return 0;
 	}
 
+	printf("failed to get pm_table from /dev/mem\n");
 	return -1;
+}
+
+bool is_using_smu_driver()
+{
+	return pm_table_fd > 0;
 }

--- a/lib/osdep_win32.cpp
+++ b/lib/osdep_win32.cpp
@@ -123,3 +123,8 @@ extern "C" int copy_from_phyaddr(void *buffer, size_t size)
     memcpy(buffer, pdwLinAddr, size);
     return 0;
 }
+
+extern "C" bool is_using_smu_driver()
+{
+    return false;
+}

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -67,6 +67,7 @@ EXP uint32_t CALL get_table_ver(ryzen_access ry);
 EXP size_t CALL get_table_size(ryzen_access ry);
 EXP float* CALL get_table_values(ryzen_access ry);
 EXP int CALL refresh_table(ryzen_access ry);
+EXP void CALL set_skip_table_transfer(ryzen_access ry, bool skip_table_transfer);
 
 EXP int CALL set_stapm_limit(ryzen_access, uint32_t value);
 EXP int CALL set_fast_limit(ryzen_access, uint32_t value);

--- a/lib/ryzenadj_priv.h
+++ b/lib/ryzenadj_priv.h
@@ -25,6 +25,7 @@ struct _ryzen_access {
 	uint32_t table_ver;
 	size_t table_size;
 	float *table_values;
+	bool skip_table_transfer;
 };
 
 enum ryzen_family cpuid_get_family();


### PR DESCRIPTION
And don't execute transfer table twice if we use smu drivers

SMU doesn't like it if multiple tools call transfer table. Make it able to skip table transfer calls via interface and avoid calling it twice if the SMU driver does already do the transfer call.

If you increase the frequency of refresh calls to over 1Hz, it is getting worse.