### PR TITLE
Allow skipping table transfer (autodetect)

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -282,11 +282,12 @@ EXP int CALL init_table(ryzen_access ry)
 
 	if(!ry->table_values[0]){
 		//Raven and Picasso don't get table refresh on the very first transfer call after boot, but respond with OK
-		//if we detact 0 data, do an initial 2nd call after a small delay (copy_pm_table is enough delay)
+		//if we detact 0 data, do an initial 2nd call after a small delay
 		//transfer, transfer, wait, wait longer; don't work
 		//transfer, wait, wait longer; don't work
 		//transfer, wait, transfer; does work
 		DBG("empty table detected, try again\n");
+		Sleep(10);
 		return refresh_table(ry);
 	}
 

--- a/lib/api.c
+++ b/lib/api.c
@@ -264,7 +264,7 @@ EXP int CALL init_table(ryzen_access ry)
 	}
 
 	//init memory object because it is prerequiremt to woring with physical memory address
-	ry->mem_obj = init_mem_obj();
+	ry->mem_obj = init_mem_obj(ry->table_addr);
 	if(!ry->mem_obj)
 	{
 		printf("Unable to get MEM Obj\n");
@@ -332,7 +332,7 @@ EXP int CALL refresh_table(ryzen_access ry)
 		return errorcode;
 	}
 
-	if(copy_from_phyaddr(ry->table_addr, ry->table_values, ry->table_size)){
+	if(copy_from_phyaddr(ry->table_values, ry->table_size)){
 		printf("refresh_table failed\n");
 		return ADJ_ERR_MEMORY_ACCESS;
 	}

--- a/lib/api.c
+++ b/lib/api.c
@@ -324,10 +324,14 @@ EXP float* CALL get_table_values(ryzen_access ry)
 
 EXP int CALL refresh_table(ryzen_access ry)
 {
-	int errorcode;
+	int errorcode = 0;
 	_lazy_init_table(errorcode);
 
-	errorcode = request_transfer_table(ry);
+	//only execute request table if we don't use SMU driver
+	if(!is_using_smu_driver()){
+		errorcode = request_transfer_table(ry);
+	}
+
 	if(errorcode){
 		return errorcode;
 	}

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -106,10 +106,10 @@ smu_t get_smu(nb_t nb, int smu_type);
 void free_smu(smu_t smu);
 u32 smu_service_req(smu_t smu ,u32 id ,smu_service_args_t *args);
 
-mem_obj_t init_mem_obj();
+mem_obj_t init_mem_obj(u32 physAddr);
 
 void free_mem_obj(mem_obj_t obj);
 
-int copy_from_phyaddr(u32 physAddr, void *buffer, size_t size);
+int copy_from_phyaddr(void *buffer, size_t size);
 
 #endif

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -112,4 +112,5 @@ void free_mem_obj(mem_obj_t obj);
 
 int copy_from_phyaddr(void *buffer, size_t size);
 
+bool is_using_smu_driver();
 #endif

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -110,7 +110,9 @@ mem_obj_t init_mem_obj(u32 physAddr);
 
 void free_mem_obj(mem_obj_t obj);
 
-int copy_from_phyaddr(void *buffer, size_t size);
+int copy_pm_table(void *buffer, size_t size);
+
+int compare_pm_table(void *buffer, size_t size);
 
 bool is_using_smu_driver();
 #endif

--- a/lib/osdep_linux.c
+++ b/lib/osdep_linux.c
@@ -11,7 +11,7 @@
 
 bool mem_obj_obj = true;
 int pm_table_fd = 0;
-int dev_mem_fd = 0;
+void *phy_map = MAP_FAILED;
 
 pci_obj_t init_pci_obj(){
 	pci_obj_t obj;
@@ -48,27 +48,41 @@ void smn_reg_write(nb_t nb, u32 addr, u32 data)
 	pci_write_long(nb, NB_PCI_REG_DATA_ADDR, data);
 }
 
-mem_obj_t init_mem_obj()
+mem_obj_t init_mem_obj(u32 physAddr)
 {
-	int dev_mem_errno, pm_table_errno;
+	int dev_mem_fd; 
+	int dev_mem_errno, mmap_errno;
 
-	//It is to complicated to check PAT, CONFIG_NONPROMISC_DEVMEM, CONFIG_STRICT_DEVMEM or other dependencies, just try to open /dev/mem and try to use it later
+	//It is to complicated to check PAT, CONFIG_NONPROMISC_DEVMEM, CONFIG_STRICT_DEVMEM or other dependencies, just try to open /dev/mem
 	dev_mem_fd = open("/dev/mem", O_RDONLY);
-	if (dev_mem_fd == -1){
-		dev_mem_errno = errno;
+	dev_mem_errno = errno;
+	if (dev_mem_fd > 0){
+		phy_map = mmap(NULL, 0x1000, PROT_READ, MAP_SHARED, dev_mem_fd, physAddr);
+		mmap_errno = errno;
+		close(dev_mem_fd);
 	}
 
-	pm_table_fd = open("/sys/kernel/ryzen_smu_drv/pm_table", O_RDONLY);
-	if (pm_table_fd == -1){
-		pm_table_errno = errno;
-	}
+	if(phy_map == MAP_FAILED){
+		//only complain about mmap errors if we don't have access to alternative smu driver
+		pm_table_fd = open("/sys/kernel/ryzen_smu_drv/pm_table", O_RDONLY);
+		if (pm_table_fd < 0) {
+			printf("failed to get /sys/kernel/ryzen_smu_drv/pm_table: %s\n", strerror(errno));
 
-	if(dev_mem_fd == -1 && dev_mem_fd -1){
-		printf("failed to get /dev/mem: %s\n", strerror(dev_mem_errno));
-		printf("failed to get /sys/kernel/ryzen_smu_drv/pm_table: %s\n", strerror(pm_table_errno));
-		printf("If you don't want to change your memory access policy, you need a kernel module for this task.\n");
-		printf("We do support usage of this kernel module https://gitlab.com/leogx9r/ryzen_smu\n");
-		return NULL;
+			//show either fd error or mmap error, depending on which was the problem
+			if(dev_mem_errno) {
+				printf("failed to get /dev/mem: %s\n", strerror(dev_mem_errno));
+			} else {
+				printf("failed to map /dev/mem: %s\n", strerror(mmap_errno));
+			}
+
+			if(mmap_errno == EPERM || dev_mem_fd < 0) {
+				//we are already superuser if memory access is requested because we did successfully do the other smu calls.
+				//missing /dev/mem or missing permissions can only mean memory access policy
+				printf("If you don't want to change your memory access policy, you need a kernel module for this task.\n");
+				printf("We do support usage of this kernel module https://gitlab.com/leogx9r/ryzen_smu\n");
+			}
+			return NULL;
+		}
 	}
 
 	return &mem_obj_obj;
@@ -76,8 +90,8 @@ mem_obj_t init_mem_obj()
 
 void free_mem_obj(mem_obj_t obj)
 {
-	if(dev_mem_fd > 0) {
-		close(dev_mem_fd);
+	if(phy_map != MAP_FAILED){
+		munmap(phy_map, 0x1000);
 	}
 	if(pm_table_fd > 0) {
 		close(pm_table_fd);
@@ -85,39 +99,30 @@ void free_mem_obj(mem_obj_t obj)
 	return;
 }
 
-int copy_from_phyaddr(u32 physAddr, void *buffer, size_t size)
+int copy_from_phyaddr(void *buffer, size_t size)
 {
-	void *phy_map;
-	int read_size, last_errno;
+	int read_size;
 
-	//use ryzen_smu kernel modul for pm table if existing
 	if(pm_table_fd > 0){
 		lseek(pm_table_fd, 0, SEEK_SET);
 		read_size = read(pm_table_fd, buffer, size);
 		if(read_size == -1) {
 			printf("failed to get pm_table from ryzen_smu kernel module: %s\n", strerror(errno));
-		} else {
-			return 0;
+			return -1;
 		}
+		return 0;
 	}
 
-	//use /dev/mem if ryzen_smu kernel module is not installed or if it did fail
-	if(dev_mem_fd > 0) {
-		phy_map = mmap(NULL, size, PROT_READ, MAP_SHARED, dev_mem_fd, physAddr);
-		if (phy_map == MAP_FAILED) {
-			last_errno = errno;
-			printf("failed to map /dev/mem: %s\n", strerror(last_errno));
-			if(last_errno == EPERM) {
-				//we are already superuser if memory access is requested because we did successfully do the other smu calls
-				printf("If you don't want to change your memory access policy, you need a kernel module for this task.\n");
-				printf("We do support usage of this kernel module https://gitlab.com/leogx9r/ryzen_smu\n");
-			}
-		} else {
-			memcpy(buffer, phy_map, size);
-			munmap(phy_map, size);
-			return 0;
-		}
+	if(phy_map != MAP_FAILED){
+		memcpy(buffer, phy_map, size);
+		return 0;
 	}
 
+	printf("failed to get pm_table from /dev/mem\n");
 	return -1;
+}
+
+bool is_using_smu_driver()
+{
+	return pm_table_fd > 0;
 }

--- a/lib/osdep_linux.c
+++ b/lib/osdep_linux.c
@@ -99,7 +99,7 @@ void free_mem_obj(mem_obj_t obj)
 	return;
 }
 
-int copy_from_phyaddr(void *buffer, size_t size)
+int copy_pm_table(void *buffer, size_t size)
 {
 	int read_size;
 
@@ -120,6 +120,15 @@ int copy_from_phyaddr(void *buffer, size_t size)
 
 	printf("failed to get pm_table from /dev/mem\n");
 	return -1;
+}
+
+int compare_pm_table(void *buffer, size_t size)
+{
+	if(pm_table_fd > 0){
+		//we can not compare to physial pm table location because we don't have direct memory access via SMU driver
+		return 0;
+	}
+	return memcmp(buffer, phy_map, size);
 }
 
 bool is_using_smu_driver()

--- a/lib/osdep_win32.cpp
+++ b/lib/osdep_win32.cpp
@@ -118,10 +118,15 @@ extern "C" void free_mem_obj(mem_obj_t hInpOutDll)
     FreeLibrary((HINSTANCE)hInpOutDll);
 }
 
-extern "C" int copy_from_phyaddr(void *buffer, size_t size)
+extern "C" int copy_pm_table(void *buffer, size_t size)
 {
     memcpy(buffer, pdwLinAddr, size);
     return 0;
+}
+
+extern "C" int compare_pm_table(void *buffer, size_t size)
+{
+    return memcmp(buffer, pdwLinAddr, size);
 }
 
 extern "C" bool is_using_smu_driver()

--- a/lib/osdep_win32.cpp
+++ b/lib/osdep_win32.cpp
@@ -123,3 +123,8 @@ extern "C" int copy_from_phyaddr(void *buffer, size_t size)
     memcpy(buffer, pdwLinAddr, size);
     return 0;
 }
+
+extern "C" bool is_using_smu_driver()
+{
+    return false;
+}


### PR DESCRIPTION
Instead of exposing internal functions, we can automatically detect if it made sense to skip table transfer.

That is much better because you don't need to check running process names to detect race conditions in transfer table calls