### PR TITLE
Quote paths in win32 service installer script.

### DIFF
--- a/win32/installServiceTask.bat
+++ b/win32/installServiceTask.bat
@@ -18,7 +18,7 @@ echo Please configure RyzenAdjService by adding your prefered values in the top 
 timeout /t 2 > NUL
 notepad "%~dp0\readjustService.ps1"
 
-powershell -Command "(gc %~dp0RyzenAdjServiceTask.xml.template) -replace '###SCRIPTPATH###', '%~dp0readjustService.ps1' | Out-File -encoding ASCII %~dp0RyzenAdjServiceTask.xml"
+powershell -Command "(gc '%~dp0RyzenAdjServiceTask.xml.template') -replace '###SCRIPTPATH###', '%~dp0readjustService.ps1' | Out-File -encoding ASCII '%~dp0RyzenAdjServiceTask.xml'"
 
 SCHTASKS /Create /TN "AMD\RyzenAdj" /XML "%~dp0RyzenAdjServiceTask.xml" /F || goto failed
 


### PR DESCRIPTION
Prevents an error if the release is installed to a path with spaces,
e.g.:

\Program Files\ryzenadj

Signed-off-by: Rafael Kitover <rkitover@gmail.com>