### PR TITLE
Add experimental support for VanGogh and Rembrandt

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -413,6 +413,8 @@ EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x14);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -429,6 +431,8 @@ EXP int CALL set_fast_limit(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x15);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -445,6 +449,8 @@ EXP int CALL set_slow_limit(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x16);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -461,6 +467,8 @@ EXP int CALL set_slow_time(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x17);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -477,6 +485,8 @@ EXP int CALL set_stapm_time(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x18);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -493,6 +503,8 @@ EXP int CALL set_tctl_temp(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x19);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -509,6 +521,8 @@ EXP int CALL set_vrm_current(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x1a);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -525,7 +539,27 @@ EXP int CALL set_vrmsoc_current(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x1b);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_vrmgfx_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x1c);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_vrmcvip_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x1d);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -541,7 +575,20 @@ EXP int CALL set_vrmmax_current(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
 		_do_adjust(0x1c);
+		break;
+	case FAM_VANGOGH:
+		_do_adjust(0x1e);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_vrmgfxmax_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x1f);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -557,6 +604,7 @@ EXP int CALL set_vrmsocmax_current(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
 		_do_adjust(0x1d);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -578,6 +626,15 @@ EXP int CALL set_psi0_current(ryzen_access ry, uint32_t value){
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
 
+EXP int CALL set_psi3cpu_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x20);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
 EXP int CALL set_psi0soc_current(ryzen_access ry, uint32_t value){
 	switch (ry->family)
 	{
@@ -590,6 +647,15 @@ EXP int CALL set_psi0soc_current(ryzen_access ry, uint32_t value){
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
 		_do_adjust(0x1f);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_psi3gfx_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x21);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -727,6 +793,11 @@ EXP int CALL set_prochot_deassertion_ramp(ryzen_access ry, uint32_t value) {
 	case FAM_CEZANNE:
 		_do_adjust(0x20);
 		break;
+	case FAM_VANGOGH:
+		_do_adjust(0x22);
+		break;
+	case FAM_REMBRANDT:
+		_do_adjust(0x1f);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -739,6 +810,10 @@ EXP int CALL set_apu_skin_temp_limit(ryzen_access ry, uint32_t value) {
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
 		_do_adjust(0x38);
+		break;
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
+		_do_adjust(0x33);
 		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -753,6 +828,10 @@ EXP int CALL set_dgpu_skin_temp_limit(ryzen_access ry, uint32_t value) {
 	case FAM_CEZANNE:
 		_do_adjust(0x39);
 		break;
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
+		_do_adjust(0x34);
+		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -765,6 +844,9 @@ EXP int CALL set_apu_slow_limit(ryzen_access ry, uint32_t value) {
 	case FAM_CEZANNE:
 		_do_adjust(0x21);
 		break;
+	case FAM_REMBRANDT:
+		_do_adjust(0x23);
+		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -776,6 +858,10 @@ EXP int CALL set_skin_temp_power_limit(ryzen_access ry, uint32_t value) {
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
 		_do_adjust(0x53);
+		break;
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
+		_do_adjust(0x4a);
 		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -803,6 +889,8 @@ EXP int CALL set_power_saving(ryzen_access ry) {
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x12);
 		break;
 	}
@@ -821,6 +909,8 @@ EXP int CALL set_max_performance(ryzen_access ry) {
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x11);
 		break;
 	}

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -59,6 +59,8 @@ enum ryzen_family cpuid_get_family()
             return FAM_RENOIR;
         case 104:
             return FAM_LUCIENNE;
+        case 144:
+            return FAM_VANGOGH;
         default:
             printf("Fam%xh: unsupported model %d\n", family, model);
             break;
@@ -69,6 +71,8 @@ enum ryzen_family cpuid_get_family()
         switch (model) {
         case 80:
             return FAM_CEZANNE;
+        case 64:
+            return FAM_REMBRANDT;
         default:
             printf("Fam%xh: unsupported model %d\n", family, model);
             break;

--- a/lib/nb_smu_ops.c
+++ b/lib/nb_smu_ops.c
@@ -68,12 +68,21 @@ smu_t get_smu(nb_t nb, int smu_type) {
 
 	smu = (smu_t)malloc((sizeof(*smu)));
 	smu->nb = nb;
+
+	enum ryzen_family family = cpuid_get_family();
+
 	/* Fill SMU information */
 	switch(smu_type){
 		case TYPE_MP1:
-			smu->msg = MP1_C2PMSG_MESSAGE_ADDR;
-			smu->rep = MP1_C2PMSG_RESPONSE_ADDR;
-			smu->arg_base = MP1_C2PMSG_ARG_BASE;
+			if (family == FAM_REMBRANDT || family == FAM_VANGOGH) {
+				smu->msg = MP1_C2PMSG_MESSAGE_ADDR_2;
+				smu->rep = MP1_C2PMSG_RESPONSE_ADDR_2;
+				smu->arg_base = MP1_C2PMSG_ARG_BASE_2;
+			} else {
+				smu->msg = MP1_C2PMSG_MESSAGE_ADDR_1;
+				smu->rep = MP1_C2PMSG_RESPONSE_ADDR_1;
+				smu->arg_base = MP1_C2PMSG_ARG_BASE_1;
+			}
 			break;
 		case TYPE_PSMU:
 			smu->msg = PSMU_C2PMSG_MESSAGE_ADDR;

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -38,9 +38,14 @@ enum SMU_TYPE{
 	TYPE_COUNT,
 };
 
-#define MP1_C2PMSG_MESSAGE_ADDR          0x3B10528
-#define MP1_C2PMSG_RESPONSE_ADDR         0x3B10564
-#define MP1_C2PMSG_ARG_BASE              0x3B10998
+#define MP1_C2PMSG_MESSAGE_ADDR_1        0x3B10528
+#define MP1_C2PMSG_RESPONSE_ADDR_1       0x3B10564
+#define MP1_C2PMSG_ARG_BASE_1            0x3B10998
+
+/* For Vangogh and Rembrandt */
+#define MP1_C2PMSG_MESSAGE_ADDR_2        0x3B10528
+#define MP1_C2PMSG_RESPONSE_ADDR_2       0x3B10578
+#define MP1_C2PMSG_ARG_BASE_2            0x3B10998
 
 #define PSMU_C2PMSG_MESSAGE_ADDR          0x3B10a20
 #define PSMU_C2PMSG_RESPONSE_ADDR         0x3B10a80

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -20,6 +20,8 @@ enum ryzen_family {
         FAM_CEZANNE,
         FAM_DALI,
         FAM_LUCIENNE,
+        FAM_VANGOGH,
+        FAM_REMBRANDT,
         FAM_END
 };
 
@@ -76,10 +78,15 @@ EXP int CALL set_stapm_time(ryzen_access, uint32_t value);
 EXP int CALL set_tctl_temp(ryzen_access, uint32_t value);
 EXP int CALL set_vrm_current(ryzen_access, uint32_t value);
 EXP int CALL set_vrmsoc_current(ryzen_access, uint32_t value);
+EXP int CALL set_vrmgfx_current(ryzen_access, uint32_t value);
+EXP int CALL set_vrmcvip_current(ryzen_access, uint32_t value);
 EXP int CALL set_vrmmax_current(ryzen_access, uint32_t value);
 EXP int CALL set_vrmsocmax_current(ryzen_access, uint32_t value);
+EXP int CALL set_vrmgfxmax_current(ryzen_access, uint32_t value);
 EXP int CALL set_psi0_current(ryzen_access, uint32_t value);
+EXP int CALL set_psi3cpu_current(ryzen_access, uint32_t value);
 EXP int CALL set_psi0soc_current(ryzen_access, uint32_t value);
+EXP int CALL set_psi3gfx_current(ryzen_access, uint32_t value);
 EXP int CALL set_max_gfxclk_freq(ryzen_access, uint32_t value);
 EXP int CALL set_min_gfxclk_freq(ryzen_access, uint32_t value);
 EXP int CALL set_max_socclk_freq(ryzen_access, uint32_t value);

--- a/main.c
+++ b/main.c
@@ -71,6 +71,8 @@ static const char *family_name(enum ryzen_family fam)
 	case FAM_CEZANNE: return "Cezanne";
 	case FAM_DALI: return "Dali";
 	case FAM_LUCIENNE: return "Lucienne";
+	case FAM_VANGOGH: return "Vangogh";
+	case FAM_REMBRANDT: return "Rembrandt";
 	default:
 		break;
 	}
@@ -190,6 +192,7 @@ int main(int argc, const char **argv)
 	//init unsigned types with max value because we treat max value as unset
 	uint32_t stapm_limit = -1, fast_limit = -1, slow_limit = -1, slow_time = -1, stapm_time = -1, tctl_temp = -1;
 	uint32_t vrm_current = -1, vrmsoc_current = -1, vrmmax_current = -1, vrmsocmax_current = -1, psi0_current = -1, psi0soc_current = -1;
+	uint32_t vrmgfx_current = -1, vrmcvip_current = -1, vrmgfxmax_current = -1, psi3cpu_current = -1, psi3gfx_current = -1;
 	uint32_t max_socclk_freq = -1, min_socclk_freq = -1, max_fclk_freq = -1, min_fclk_freq = -1, max_vcn = -1, min_vcn = -1, max_lclk = -1, min_lclk = -1;
 	uint32_t max_gfxclk_freq = -1, min_gfxclk_freq = -1, prochot_deassertion_ramp = -1, apu_skin_temp_limit = -1, dgpu_skin_temp_limit = -1, apu_slow_limit = -1;
 	uint32_t skin_temp_power_limit = -1;
@@ -210,10 +213,15 @@ int main(int argc, const char **argv)
 		OPT_U32('f', "tctl-temp", &tctl_temp, "Tctl Temperature Limit (degree C)"),
 		OPT_U32('g', "vrm-current", &vrm_current, "VRM Current Limit             - TDC LIMIT VDD (mA)"),
 		OPT_U32('j', "vrmsoc-current", &vrmsoc_current, "VRM SoC Current Limit         - TDC LIMIT SoC (mA)"),
+		OPT_U32('\0', "vrmgfx-current", &vrmgfx_current, "VRM GFX Current Limit - TDC LIMIT GFX (mA)"),
+		OPT_U32('\0', "vrmcvip-current", &vrmcvip_current, "VRM CVIP Current Limit - TDC LIMIT CVIP (mA)"),
 		OPT_U32('k', "vrmmax-current", &vrmmax_current, "VRM Maximum Current Limit     - EDC LIMIT VDD (mA)"),
 		OPT_U32('l', "vrmsocmax-current", &vrmsocmax_current, "VRM SoC Maximum Current Limit - EDC LIMIT SoC (mA)"),
+		OPT_U32('\0', "vrmgfxmax_current", &vrmgfxmax_current, "VRM GFX Maximum Current Limit - EDC LIMIT GFX (mA)"),
 		OPT_U32('m', "psi0-current", &psi0_current, "PSI0 VDD Current Limit (mA)"),
+		OPT_U32('\0', "psi3cpu_current", &psi3cpu_current, "PSI3 CPU Current Limit (mA)"),
 		OPT_U32('n', "psi0soc-current", &psi0soc_current, "PSI0 SoC Current Limit (mA)"),
+		OPT_U32('\0', "psi3gfx_current", &psi3gfx_current, "PSI3 GFX Current Limit (mA)"),
 		OPT_U32('o', "max-socclk-frequency", &max_socclk_freq, "Maximum SoC Clock Frequency (MHz)"),
 		OPT_U32('p', "min-socclk-frequency", &min_socclk_freq, "Minimum SoC Clock Frequency (MHz)"),
 		OPT_U32('q', "max-fclk-frequency", &max_fclk_freq, "Maximum Transmission (CPU-GPU) Frequency (MHz)"),
@@ -272,10 +280,15 @@ int main(int argc, const char **argv)
 	_do_adjust(tctl_temp);
 	_do_adjust(vrm_current);
 	_do_adjust(vrmsoc_current);
+	_do_adjust(vrmgfx_current);
+	_do_adjust(vrmcvip_current);
 	_do_adjust(vrmmax_current);
 	_do_adjust(vrmsocmax_current);
+	_do_adjust(vrmgfxmax_current);
 	_do_adjust(psi0_current);
+	_do_adjust(psi3cpu_current);
 	_do_adjust(psi0soc_current);
+	_do_adjust(psi3gfx_current);
 	_do_adjust(max_socclk_freq);
 	_do_adjust(min_socclk_freq);
 	_do_adjust(max_fclk_freq);


### PR DESCRIPTION
For some unknown reason my pull request was not updated with my squashed commit... So I had to create a new one. I also changed the indentation. :)

This pull request adds experimental support for Van Gogh and Rembrandt. I also added 5 new functions to set the VRM GFX and CVIP current as well as the PSI3 current.

Support for the PMTable will follow as soon as I get my hands on these CPUs. 😃 