### PR TITLE
CPU overclocking support for unlocked APUs and additional sensors for Renoir/Lucienne/Cezanne/Barcelo/Van Gogh APUs

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Adjust power management settings for Ryzen Mobile Processors.
 
 Based on: [FlyGoat/ryzen_nb_smu](https://github.com/flygoat/ryzen_nb_smu)
 
-RyzenAdjUI_WPF by "JustSkill" is no longer maintained, for GUI please see [AMD APU Tuning Utility](https://github.com/JamesCJ60/AMD-APU-Tuning-Utility).
+RyzenAdjUI_WPF by "JustSkill" is no longer maintained, for GUI please see [ryzen-controller-team/ryzen-controller](https://gitlab.com/ryzen-controller-team/ryzen-controller/) or [AMD APU Tuning Utility](https://github.com/JamesCJ60/AMD-APU-Tuning-Utility).
 
 ## Usage
 The command line interface is identical on both Windows and Unix-Like OS.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Adjust power management settings for Ryzen Mobile Processors.
 
 Based on: [FlyGoat/ryzen_nb_smu](https://github.com/flygoat/ryzen_nb_smu)
 
-RyzenAdjUI_WPF by "JustSkill" is no longer maintained, for GUI please see [ryzen-controller-team/ryzen-controller](https://gitlab.com/ryzen-controller-team/ryzen-controller/).
+RyzenAdjUI_WPF by "JustSkill" is no longer maintained, for GUI please see [AMD APU Tuning Utility](https://github.com/JamesCJ60/AMD-APU-Tuning-Utility).
 
 ## Usage
 The command line interface is identical on both Windows and Unix-Like OS.

--- a/lib/api.c
+++ b/lib/api.c
@@ -22,6 +22,12 @@ EXP ryzen_access CALL init_ryzenadj()
 
 	ry = (ryzen_access)malloc((sizeof(*ry)));
 
+	if (!ry){
+		printf("Out of memory\n");
+		return NULL;
+	}
+	memset(ry, 0, sizeof(*ry));
+
 	ry->family = family;
 	//init version and power metric table only on demand to avoid unnecessary SMU writes
 	ry->bios_if_ver = 0;
@@ -143,25 +149,25 @@ int request_table_ver_and_size(ryzen_access ry)
 
 	switch (ry->table_ver)
 	{
-		case 0x1E0001: ry->table_size = 0x568; break;
-		case 0x1E0002: ry->table_size = 0x580; break;
-		case 0x1E0003: ry->table_size = 0x578; break;
-		case 0x1E0004: ry->table_size = 0x608; break;
-		case 0x1E0005: ry->table_size = 0x608; break;
-		case 0x1E000A: ry->table_size = 0x608; break;
-		case 0x1E0101: ry->table_size = 0x608; break;
-		case 0x370000: ry->table_size = 0x794; break;
-		case 0x370001: ry->table_size = 0x884; break;
-		case 0x370002: ry->table_size = 0x88C; break;
-		case 0x370003: ry->table_size = 0x8AC; break;
-		case 0x370004: ry->table_size = 0x8AC; break;
-		case 0x370005: ry->table_size = 0x8C8; break;
-		case 0x400001: ry->table_size = 0x910; break;
-		case 0x400002: ry->table_size = 0x928; break;
-		case 0x400003: ry->table_size = 0x94C; break;
-		case 0x400004: ry->table_size = 0x944; break;
-		case 0x400005: ry->table_size = 0x944; break;
-		case 0x3F0000: ry->table_size = 0x7AC; break;
+	case 0x1E0001: ry->table_size = 0x568; break;
+	case 0x1E0002: ry->table_size = 0x580; break;
+	case 0x1E0003: ry->table_size = 0x578; break;
+	case 0x1E0004: ry->table_size = 0x608; break;
+	case 0x1E0005: ry->table_size = 0x608; break;
+	case 0x1E000A: ry->table_size = 0x608; break;
+	case 0x1E0101: ry->table_size = 0x608; break;
+	case 0x370000: ry->table_size = 0x794; break;
+	case 0x370001: ry->table_size = 0x884; break;
+	case 0x370002: ry->table_size = 0x88C; break;
+	case 0x370003: ry->table_size = 0x8AC; break;
+	case 0x370004: ry->table_size = 0x8AC; break;
+	case 0x370005: ry->table_size = 0x8C8; break;
+	case 0x400001: ry->table_size = 0x910; break;
+	case 0x400002: ry->table_size = 0x928; break;
+	case 0x400003: ry->table_size = 0x94C; break;
+	case 0x400004: ry->table_size = 0x944; break;
+	case 0x400005: ry->table_size = 0x944; break;
+	case 0x3F0000: ry->table_size = 0x7AC; break;
 		default:
 			//use a larger size then the largest known table to be able to test real table size of unknown tables
 			ry->table_size = 0xA00;
@@ -776,6 +782,7 @@ EXP int CALL set_skin_temp_power_limit(ryzen_access ry, uint32_t value) {
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
 
+
 EXP int CALL set_gfx_clk(ryzen_access ry, uint32_t value) {
 	switch (ry->family)
 	{
@@ -901,7 +908,7 @@ EXP float CALL get_slow_limit(ryzen_access ry){_read_float_value(0x10);}
 EXP float CALL get_slow_value(ryzen_access ry){_read_float_value(0x14);}
 
 //custom section, offsets are depending on table version
-EXP float CALL get_apu_slow_limit(ryzen_access ry){
+EXP float CALL get_apu_slow_limit(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -920,7 +927,7 @@ EXP float CALL get_apu_slow_limit(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_apu_slow_value(ryzen_access ry){
+EXP float CALL get_apu_slow_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -939,7 +946,7 @@ EXP float CALL get_apu_slow_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrm_current(ryzen_access ry){
+EXP float CALL get_vrm_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -965,7 +972,7 @@ EXP float CALL get_vrm_current(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrm_current_value(ryzen_access ry){
+EXP float CALL get_vrm_current_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -991,7 +998,7 @@ EXP float CALL get_vrm_current_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmsoc_current(ryzen_access ry){
+EXP float CALL get_vrmsoc_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1017,7 +1024,7 @@ EXP float CALL get_vrmsoc_current(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmsoc_current_value(ryzen_access ry){
+EXP float CALL get_vrmsoc_current_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1043,7 +1050,7 @@ EXP float CALL get_vrmsoc_current_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmmax_current(ryzen_access ry){
+EXP float CALL get_vrmmax_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1069,7 +1076,7 @@ EXP float CALL get_vrmmax_current(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmmax_current_value(ryzen_access ry){
+EXP float CALL get_vrmmax_current_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1095,7 +1102,7 @@ EXP float CALL get_vrmmax_current_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmsocmax_current(ryzen_access ry){
+EXP float CALL get_vrmsocmax_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1121,7 +1128,7 @@ EXP float CALL get_vrmsocmax_current(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmsocmax_current_value(ryzen_access ry){
+EXP float CALL get_vrmsocmax_current_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1147,7 +1154,7 @@ EXP float CALL get_vrmsocmax_current_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_tctl_temp(ryzen_access ry){
+EXP float CALL get_tctl_temp(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1174,7 +1181,7 @@ EXP float CALL get_tctl_temp(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_tctl_temp_value(ryzen_access ry){
+EXP float CALL get_tctl_temp_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1201,7 +1208,7 @@ EXP float CALL get_tctl_temp_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_apu_skin_temp_limit(ryzen_access ry){
+EXP float CALL get_apu_skin_temp_limit(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -1220,7 +1227,7 @@ EXP float CALL get_apu_skin_temp_limit(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_apu_skin_temp_value(ryzen_access ry){
+EXP float CALL get_apu_skin_temp_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -1239,7 +1246,7 @@ EXP float CALL get_apu_skin_temp_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry){
+EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -1257,7 +1264,7 @@ EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry){
+EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -1276,7 +1283,7 @@ EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry){
 	return NAN;
 }
 
-EXP float CALL get_psi0_current(ryzen_access ry){
+EXP float CALL get_psi0_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1303,7 +1310,7 @@ EXP float CALL get_psi0_current(ryzen_access ry){
 	return NAN;
 }
 
-EXP float CALL get_psi0soc_current(ryzen_access ry){
+EXP float CALL get_psi0soc_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1330,7 +1337,7 @@ EXP float CALL get_psi0soc_current(ryzen_access ry){
 	return NAN;
 }
 
-EXP float CALL get_cclk_setpoint(ryzen_access ry){
+EXP float CALL get_cclk_setpoint(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1358,7 +1365,7 @@ EXP float CALL get_cclk_setpoint(ryzen_access ry){
 	return NAN;
 }
 
-EXP float CALL get_cclk_busy_value(ryzen_access ry){
+EXP float CALL get_cclk_busy_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1423,7 +1430,7 @@ EXP float CALL get_stapm_time(ryzen_access ry)
 	return NAN;
 }
 
-EXP float CALL get_slow_time(ryzen_access ry){
+EXP float CALL get_slow_time(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0002:
@@ -1555,7 +1562,7 @@ EXP float CALL get_core_power(ryzen_access ry, uint32_t core) {
 		case 0x00400005:
 			_read_float_value(0x330); //816
 		}
-	
+
 	case 5:
 		switch (ry->table_ver)
 		{
@@ -1696,7 +1703,7 @@ EXP float CALL get_core_volt(ryzen_access ry, uint32_t core) {
 		case 0x00400004:
 		case 0x00400005:
 			_read_float_value(0x350); //848
-		
+
 		}
 	case 5:
 		switch (ry->table_ver)
@@ -2277,3 +2284,4 @@ EXP float CALL get_socket_power(ryzen_access ry) {
 	}
 	return NAN;
 }
+

--- a/lib/api.c
+++ b/lib/api.c
@@ -414,6 +414,8 @@ EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x14);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -430,6 +432,8 @@ EXP int CALL set_fast_limit(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x15);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -446,6 +450,8 @@ EXP int CALL set_slow_limit(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x16);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -462,6 +468,8 @@ EXP int CALL set_slow_time(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x17);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -478,6 +486,8 @@ EXP int CALL set_stapm_time(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x18);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -494,6 +504,8 @@ EXP int CALL set_tctl_temp(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x19);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -510,6 +522,8 @@ EXP int CALL set_vrm_current(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x1a);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -526,7 +540,27 @@ EXP int CALL set_vrmsoc_current(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x1b);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_vrmgfx_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x1c);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_vrmcvip_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x1d);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -542,7 +576,20 @@ EXP int CALL set_vrmmax_current(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
 		_do_adjust(0x1c);
+		break;
+	case FAM_VANGOGH:
+		_do_adjust(0x1e);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_vrmgfxmax_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x1f);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -558,6 +605,7 @@ EXP int CALL set_vrmsocmax_current(ryzen_access ry, uint32_t value){
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
 		_do_adjust(0x1d);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -579,6 +627,15 @@ EXP int CALL set_psi0_current(ryzen_access ry, uint32_t value){
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
 
+EXP int CALL set_psi3cpu_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x20);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
 EXP int CALL set_psi0soc_current(ryzen_access ry, uint32_t value){
 	switch (ry->family)
 	{
@@ -591,6 +648,15 @@ EXP int CALL set_psi0soc_current(ryzen_access ry, uint32_t value){
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
 		_do_adjust(0x1f);
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_psi3gfx_current(ryzen_access ry, uint32_t value){
+	switch (ry->family)
+	{
+	case FAM_VANGOGH:
+		_do_adjust(0x21);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -728,6 +794,11 @@ EXP int CALL set_prochot_deassertion_ramp(ryzen_access ry, uint32_t value) {
 	case FAM_CEZANNE:
 		_do_adjust(0x20);
 		break;
+	case FAM_VANGOGH:
+		_do_adjust(0x22);
+		break;
+	case FAM_REMBRANDT:
+		_do_adjust(0x1f);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -740,6 +811,10 @@ EXP int CALL set_apu_skin_temp_limit(ryzen_access ry, uint32_t value) {
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
 		_do_adjust(0x38);
+		break;
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
+		_do_adjust(0x33);
 		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -754,6 +829,10 @@ EXP int CALL set_dgpu_skin_temp_limit(ryzen_access ry, uint32_t value) {
 	case FAM_CEZANNE:
 		_do_adjust(0x39);
 		break;
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
+		_do_adjust(0x34);
+		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -765,6 +844,9 @@ EXP int CALL set_apu_slow_limit(ryzen_access ry, uint32_t value) {
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
 		_do_adjust(0x21);
+		break;
+	case FAM_REMBRANDT:
+		_do_adjust(0x23);
 		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -778,86 +860,20 @@ EXP int CALL set_skin_temp_power_limit(ryzen_access ry, uint32_t value) {
 	case FAM_CEZANNE:
 		_do_adjust(0x53);
 		break;
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
+		_do_adjust(0x4a);
+		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
-
 
 EXP int CALL set_gfx_clk(ryzen_access ry, uint32_t value) {
 	switch (ry->family)
 	{
-	case FAM_LUCIENNE:
 	case FAM_RENOIR:
+	case FAM_LUCIENNE:
 		_do_adjust_psmu(0x89);
-	case FAM_CEZANNE:
-		_do_adjust_psmu(0x89);
-		_do_adjust_psmu(0x90);
-		_do_adjust_psmu(0x1c);
-		break;
-	}
-	return ADJ_ERR_FAM_UNSUPPORTED;
-}
-
-EXP int CALL set_oc_clk(ryzen_access ry, uint32_t value) {
-	switch (ry->family)
-	{
-	case FAM_LUCIENNE:
-	case FAM_RENOIR:
-	case FAM_CEZANNE:
-		_do_adjust(0x31);
-		break;
-	}
-	return ADJ_ERR_FAM_UNSUPPORTED;
-}
-
-EXP int CALL set_per_core_oc_clk(ryzen_access ry, uint32_t value) {
-	switch (ry->family)
-	{
-	case FAM_LUCIENNE:
-	case FAM_RENOIR:
-	case FAM_CEZANNE:
-		_do_adjust(0x32);
-		_do_adjust_psmu(0x1a);
-		break;
-	}
-	return ADJ_ERR_FAM_UNSUPPORTED;
-}
-
-EXP int CALL set_oc_volt(ryzen_access ry, uint32_t value) {
-	switch (ry->family)
-	{
-	case FAM_LUCIENNE:
-	case FAM_RENOIR:
-	case FAM_CEZANNE:
-		_do_adjust(0x33);
-		_do_adjust_psmu(0x1b);
-		break;
-	}
-	return ADJ_ERR_FAM_UNSUPPORTED;
-}
-
-EXP int CALL disable_oc(ryzen_access ry) {
-	uint32_t value = 0x0;
-	switch (ry->family)
-	{
-	case FAM_LUCIENNE:
-	case FAM_RENOIR:
-	case FAM_CEZANNE:
-		_do_adjust(0x30);
-		_do_adjust_psmu(0x1d);
-		break;
-	}
-	return ADJ_ERR_FAM_UNSUPPORTED;
-}
-
-EXP int CALL enable_oc(ryzen_access ry) {
-	uint32_t value = 0x0;
-	switch (ry->family)
-	{
-	case FAM_LUCIENNE:
-	case FAM_RENOIR:
-	case FAM_CEZANNE:
-		_do_adjust(0x2F);
 		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -875,6 +891,8 @@ EXP int CALL set_power_saving(ryzen_access ry) {
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x12);
 		break;
 	}
@@ -893,7 +911,79 @@ EXP int CALL set_max_performance(ryzen_access ry) {
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 	case FAM_CEZANNE:
+	case FAM_VANGOGH:
+	case FAM_REMBRANDT:
 		_do_adjust(0x11);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_oc_clk(ryzen_access ry, uint32_t value) {
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x31);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_per_core_oc_clk(ryzen_access ry, uint32_t value) {
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x32);
+		_do_adjust_psmu(0x1a);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_oc_volt(ryzen_access ry, uint32_t value) {
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x33);
+		_do_adjust_psmu(0x1b);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL disable_oc(ryzen_access ry) {
+	uint32_t value = 0x0;
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x30);
+		_do_adjust_psmu(0x1d);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL enable_oc(ryzen_access ry) {
+	uint32_t value = 0x0;
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x2F);
 		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;

--- a/lib/api.c
+++ b/lib/api.c
@@ -417,6 +417,7 @@ EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){
 	case FAM_VANGOGH:
 	case FAM_REMBRANDT:
 		_do_adjust(0x14);
+		_do_adjust_psmu(0x31);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -927,6 +928,7 @@ EXP int CALL set_oc_clk(ryzen_access ry, uint32_t value) {
 	case FAM_CEZANNE:
 	case FAM_REMBRANDT:
 		_do_adjust(0x31);
+		_do_adjust_psmu(0x19);
 		break;
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
@@ -960,7 +962,7 @@ EXP int CALL set_oc_volt(ryzen_access ry, uint32_t value) {
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
 
-EXP int CALL disable_oc(ryzen_access ry) {
+EXP int CALL set_disable_oc(ryzen_access ry) {
 	uint32_t value = 0x0;
 	switch (ry->family)
 	{
@@ -975,7 +977,7 @@ EXP int CALL disable_oc(ryzen_access ry) {
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
 
-EXP int CALL enable_oc(ryzen_access ry) {
+EXP int CALL set_enable_oc(ryzen_access ry) {
 	uint32_t value = 0x0;
 	switch (ry->family)
 	{

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -59,6 +59,8 @@ enum ryzen_family cpuid_get_family()
             return FAM_RENOIR;
         case 104:
             return FAM_LUCIENNE;
+        case 144:
+            return FAM_VANGOGH;
         default:
             printf("Fam%xh: unsupported model %d\n", family, model);
             break;
@@ -69,6 +71,8 @@ enum ryzen_family cpuid_get_family()
         switch (model) {
         case 80:
             return FAM_CEZANNE;
+        case 64:
+            return FAM_REMBRANDT;
         default:
             printf("Fam%xh: unsupported model %d\n", family, model);
             break;

--- a/lib/nb_smu_ops.c
+++ b/lib/nb_smu_ops.c
@@ -68,12 +68,21 @@ smu_t get_smu(nb_t nb, int smu_type) {
 
 	smu = (smu_t)malloc((sizeof(*smu)));
 	smu->nb = nb;
+
+	enum ryzen_family family = cpuid_get_family();
+
 	/* Fill SMU information */
 	switch(smu_type){
 		case TYPE_MP1:
-			smu->msg = MP1_C2PMSG_MESSAGE_ADDR;
-			smu->rep = MP1_C2PMSG_RESPONSE_ADDR;
-			smu->arg_base = MP1_C2PMSG_ARG_BASE;
+			if (family == FAM_REMBRANDT || family == FAM_VANGOGH) {
+				smu->msg = MP1_C2PMSG_MESSAGE_ADDR_2;
+				smu->rep = MP1_C2PMSG_RESPONSE_ADDR_2;
+				smu->arg_base = MP1_C2PMSG_ARG_BASE_2;
+			} else {
+				smu->msg = MP1_C2PMSG_MESSAGE_ADDR_1;
+				smu->rep = MP1_C2PMSG_RESPONSE_ADDR_1;
+				smu->arg_base = MP1_C2PMSG_ARG_BASE_1;
+			}
 			break;
 		case TYPE_PSMU:
 			smu->msg = PSMU_C2PMSG_MESSAGE_ADDR;

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -38,9 +38,14 @@ enum SMU_TYPE{
 	TYPE_COUNT,
 };
 
-#define MP1_C2PMSG_MESSAGE_ADDR          0x3B10528
-#define MP1_C2PMSG_RESPONSE_ADDR         0x3B10564
-#define MP1_C2PMSG_ARG_BASE              0x3B10998
+#define MP1_C2PMSG_MESSAGE_ADDR_1        0x3B10528
+#define MP1_C2PMSG_RESPONSE_ADDR_1       0x3B10564
+#define MP1_C2PMSG_ARG_BASE_1            0x3B10998
+
+/* For Vangogh and Rembrandt */
+#define MP1_C2PMSG_MESSAGE_ADDR_2        0x3B10528
+#define MP1_C2PMSG_RESPONSE_ADDR_2       0x3B10578
+#define MP1_C2PMSG_ARG_BASE_2            0x3B10998
 
 #define PSMU_C2PMSG_MESSAGE_ADDR          0x3B10a20
 #define PSMU_C2PMSG_RESPONSE_ADDR         0x3B10a80

--- a/lib/osdep_win32.cpp
+++ b/lib/osdep_win32.cpp
@@ -31,8 +31,6 @@ HANDLE physicalMemoryHandle;
 extern "C" pci_obj_t init_pci_obj(){
     InitializeOls();
     int dllStatus = GetDllStatus();
-    if(dllStatus == 0)
-        return &nb_pci_obj;
     switch(dllStatus)
     {
         case OLS_DLL_NO_ERROR: return &nb_pci_obj;
@@ -54,6 +52,8 @@ extern "C" pci_obj_t init_pci_obj(){
         case OLS_DLL_UNKNOWN_ERROR:
             printf("WinRing0 Err: unknown error\n");
             break;
+        default:
+            printf("WinRing0 Err: unknown status code %d\n", dllStatus);
     }
     
     return NULL;

--- a/lib/osdep_win32.cpp
+++ b/lib/osdep_win32.cpp
@@ -31,6 +31,8 @@ HANDLE physicalMemoryHandle;
 extern "C" pci_obj_t init_pci_obj(){
     InitializeOls();
     int dllStatus = GetDllStatus();
+    if(dllStatus == 0)
+        return &nb_pci_obj;
     switch(dllStatus)
     {
         case OLS_DLL_NO_ERROR: return &nb_pci_obj;
@@ -52,8 +54,6 @@ extern "C" pci_obj_t init_pci_obj(){
         case OLS_DLL_UNKNOWN_ERROR:
             printf("WinRing0 Err: unknown error\n");
             break;
-        default:
-            printf("WinRing0 Err: unknown status code %d\n", dllStatus);
     }
     
     return NULL;

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -20,6 +20,8 @@ enum ryzen_family {
         FAM_CEZANNE,
         FAM_DALI,
         FAM_LUCIENNE,
+        FAM_VANGOGH,
+        FAM_REMBRANDT,
         FAM_END
 };
 
@@ -154,8 +156,6 @@ EXP float CALL get_soc_power(ryzen_access ry);
 EXP float CALL get_soc_volt(ryzen_access ry);
 
 EXP float CALL get_socket_power(ryzen_access ry);
-
-
 
 #ifdef __cplusplus
 }

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -155,6 +155,8 @@ EXP float CALL get_soc_volt(ryzen_access ry);
 
 EXP float CALL get_socket_power(ryzen_access ry);
 
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define RYZENADJ_REVISION_VER 0
 #define RYZENADJ_MAJOR_VER 8
-#define RYZENADJ_MINIOR_VER 2
+#define RYZENADJ_MINIOR_VER 3
 
 enum ryzen_family {
         FAM_UNKNOWN = -1,
@@ -95,6 +95,12 @@ EXP int CALL set_apu_skin_temp_limit(ryzen_access, uint32_t value);
 EXP int CALL set_dgpu_skin_temp_limit(ryzen_access, uint32_t value);
 EXP int CALL set_apu_slow_limit(ryzen_access, uint32_t value);
 EXP int CALL set_skin_temp_power_limit(ryzen_access ry, uint32_t value);
+EXP int CALL set_gfx_clk(ryzen_access ry, uint32_t value);
+EXP int CALL set_oc_clk(ryzen_access ry, uint32_t value);
+EXP int CALL set_per_core_oc_clk(ryzen_access ry, uint32_t value);
+EXP int CALL set_oc_volt(ryzen_access ry, uint32_t value);
+EXP int CALL disable_oc(ryzen_access ry);
+EXP int CALL enable_oc(ryzen_access ry);
 EXP int CALL set_power_saving(ryzen_access ry);
 EXP int CALL set_max_performance(ryzen_access ry);
 
@@ -127,6 +133,27 @@ EXP float CALL get_slow_time(ryzen_access ry);
 EXP float CALL get_cclk_setpoint(ryzen_access ry);
 EXP float CALL get_cclk_busy_value(ryzen_access ry);
 
+EXP float CALL get_core_clk(ryzen_access ry, uint32_t value);
+EXP float CALL get_core_volt(ryzen_access ry, uint32_t value);
+EXP float CALL get_core_power(ryzen_access ry, uint32_t value);
+EXP float CALL get_core_temp(ryzen_access ry, uint32_t value);
+
+EXP float CALL get_l3_clk(ryzen_access ry);
+EXP float CALL get_l3_logic(ryzen_access ry);
+EXP float CALL get_l3_vddm(ryzen_access ry);
+EXP float CALL get_l3_temp(ryzen_access ry);
+
+EXP float CALL get_gfx_clk(ryzen_access ry);
+EXP float CALL get_gfx_temp(ryzen_access ry);
+EXP float CALL get_gfx_volt(ryzen_access ry);
+
+EXP float CALL get_mem_clk(ryzen_access ry);
+EXP float CALL get_fclk(ryzen_access ry);
+
+EXP float CALL get_soc_power(ryzen_access ry);
+EXP float CALL get_soc_volt(ryzen_access ry);
+
+EXP float CALL get_socket_power(ryzen_access ry);
 
 #ifdef __cplusplus
 }

--- a/main.c
+++ b/main.c
@@ -71,6 +71,8 @@ static const char *family_name(enum ryzen_family fam)
 	case FAM_CEZANNE: return "Cezanne";
 	case FAM_DALI: return "Dali";
 	case FAM_LUCIENNE: return "Lucienne";
+	case FAM_VANGOGH: return "Vangogh";
+	case FAM_REMBRANDT: return "Rembrandt";
 	default:
 		break;
 	}
@@ -190,6 +192,7 @@ int main(int argc, const char **argv)
 	//init unsigned types with max value because we treat max value as unset
 	uint32_t stapm_limit = -1, fast_limit = -1, slow_limit = -1, slow_time = -1, stapm_time = -1, tctl_temp = -1;
 	uint32_t vrm_current = -1, vrmsoc_current = -1, vrmmax_current = -1, vrmsocmax_current = -1, psi0_current = -1, psi0soc_current = -1;
+	uint32_t vrmgfx_current = -1, vrmcvip_current = -1, vrmgfxmax_current = -1, psi3cpu_current = -1, psi3gfx_current = -1;
 	uint32_t max_socclk_freq = -1, min_socclk_freq = -1, max_fclk_freq = -1, min_fclk_freq = -1, max_vcn = -1, min_vcn = -1, max_lclk = -1, min_lclk = -1;
 	uint32_t max_gfxclk_freq = -1, min_gfxclk_freq = -1, prochot_deassertion_ramp = -1, apu_skin_temp_limit = -1, dgpu_skin_temp_limit = -1, apu_slow_limit = -1;
 	uint32_t skin_temp_power_limit = -1;
@@ -210,10 +213,15 @@ int main(int argc, const char **argv)
 		OPT_U32('f', "tctl-temp", &tctl_temp, "Tctl Temperature Limit (degree C)"),
 		OPT_U32('g', "vrm-current", &vrm_current, "VRM Current Limit             - TDC LIMIT VDD (mA)"),
 		OPT_U32('j', "vrmsoc-current", &vrmsoc_current, "VRM SoC Current Limit         - TDC LIMIT SoC (mA)"),
+		OPT_U32('\0', "vrmgfx-current", &vrmgfx_current, "VRM GFX Current Limit - TDC LIMIT GFX (mA)"),
+		OPT_U32('\0', "vrmcvip-current", &vrmcvip_current, "VRM CVIP Current Limit - TDC LIMIT CVIP (mA)"),
 		OPT_U32('k', "vrmmax-current", &vrmmax_current, "VRM Maximum Current Limit     - EDC LIMIT VDD (mA)"),
 		OPT_U32('l', "vrmsocmax-current", &vrmsocmax_current, "VRM SoC Maximum Current Limit - EDC LIMIT SoC (mA)"),
+		OPT_U32('\0', "vrmgfxmax_current", &vrmgfxmax_current, "VRM GFX Maximum Current Limit - EDC LIMIT GFX (mA)"),
 		OPT_U32('m', "psi0-current", &psi0_current, "PSI0 VDD Current Limit (mA)"),
+		OPT_U32('\0', "psi3cpu_current", &psi3cpu_current, "PSI3 CPU Current Limit (mA)"),
 		OPT_U32('n', "psi0soc-current", &psi0soc_current, "PSI0 SoC Current Limit (mA)"),
+		OPT_U32('\0', "psi3gfx_current", &psi3gfx_current, "PSI3 GFX Current Limit (mA)"),
 		OPT_U32('o', "max-socclk-frequency", &max_socclk_freq, "Maximum SoC Clock Frequency (MHz)"),
 		OPT_U32('p', "min-socclk-frequency", &min_socclk_freq, "Minimum SoC Clock Frequency (MHz)"),
 		OPT_U32('q', "max-fclk-frequency", &max_fclk_freq, "Maximum Transmission (CPU-GPU) Frequency (MHz)"),
@@ -272,10 +280,15 @@ int main(int argc, const char **argv)
 	_do_adjust(tctl_temp);
 	_do_adjust(vrm_current);
 	_do_adjust(vrmsoc_current);
+	_do_adjust(vrmgfx_current);
+	_do_adjust(vrmcvip_current);
 	_do_adjust(vrmmax_current);
 	_do_adjust(vrmsocmax_current);
+	_do_adjust(vrmgfxmax_current);
 	_do_adjust(psi0_current);
+	_do_adjust(psi3cpu_current);
 	_do_adjust(psi0soc_current);
+	_do_adjust(psi3gfx_current);
 	_do_adjust(max_socclk_freq);
 	_do_adjust(min_socclk_freq);
 	_do_adjust(max_fclk_freq);

--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ do {                                                                            
 		int adjerr = set_##ARG(ry);                                               \
 		if (!adjerr){                                                             \
 			any_adjust_applied = 1;                                               \
-			printf("Sucessfully enable " STRINGIFY(ARG) "\n");                    \
+			printf("Sucessfully enable " STRINGIFY(ARG) );                        \
 		} else if (adjerr == ADJ_ERR_FAM_UNSUPPORTED) {                           \
 			printf("set_" STRINGIFY(ARG) " is not supported on this family\n");   \
 			err = -1;                                                             \
@@ -92,7 +92,7 @@ static void show_info_table(ryzen_access ry)
 	//get refresh table after adjust
 	int errorcode = refresh_table(ry);
 	if(errorcode){
-		printf("Unable to refresh power metric table: %d\n", errorcode);
+		printf("Unable to refresh power monitoring table: %d\n", errorcode);
 		return;
 	}
 
@@ -193,6 +193,7 @@ int main(int argc, const char **argv)
 	uint32_t max_socclk_freq = -1, min_socclk_freq = -1, max_fclk_freq = -1, min_fclk_freq = -1, max_vcn = -1, min_vcn = -1, max_lclk = -1, min_lclk = -1;
 	uint32_t max_gfxclk_freq = -1, min_gfxclk_freq = -1, prochot_deassertion_ramp = -1, apu_skin_temp_limit = -1, dgpu_skin_temp_limit = -1, apu_slow_limit = -1;
 	uint32_t skin_temp_power_limit = -1;
+	uint32_t gfx_clk = -1;
 
 	//create structure for parseing
 	struct argparse_option options[] = {
@@ -228,6 +229,7 @@ int main(int argc, const char **argv)
 		OPT_U32('\0', "dgpu-skin-temp", &dgpu_skin_temp_limit, "dGPU Skin Temperature Limit   - STT LIMIT dGPU (degree C)"),
 		OPT_U32('\0', "apu-slow-limit", &apu_slow_limit, "APU PPT Slow Power limit for A+A dGPU platform - PPT LIMIT APU (mW)"),
 		OPT_U32('\0', "skin-temp-limit", &skin_temp_power_limit, "Skin Temperature Power Limit (mW)"),
+		OPT_U32('\0', "gfx-clk", &gfx_clk, "Forced Clock Speed MHz (Renoir Only)"),
 		OPT_BOOLEAN('\0', "power-saving", &power_saving, "Hidden options to improve power efficiency (is set when AC unplugged): behavior depends on CPU generation, Device and Manufacture"),
 		OPT_BOOLEAN('\0', "max-performance", &max_performance, "Hidden options to improve performance (is set when AC plugged in): behavior depends on CPU generation, Device and Manufacture"),
 		OPT_GROUP("P-State Functions"),
@@ -289,6 +291,7 @@ int main(int argc, const char **argv)
 	_do_adjust(dgpu_skin_temp_limit);
 	_do_adjust(apu_slow_limit);
 	_do_adjust(skin_temp_power_limit);
+	_do_adjust(gfx_clk);
 	_do_enable(power_saving);
 	_do_enable(max_performance);
 

--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ do {                                                                            
 		int adjerr = set_##ARG(ry);                                               \
 		if (!adjerr){                                                             \
 			any_adjust_applied = 1;                                               \
-			printf("Sucessfully enable " STRINGIFY(ARG) );                        \
+			printf("Sucessfully enable " STRINGIFY(ARG) "\n");                    \
 		} else if (adjerr == ADJ_ERR_FAM_UNSUPPORTED) {                           \
 			printf("set_" STRINGIFY(ARG) " is not supported on this family\n");   \
 			err = -1;                                                             \
@@ -92,7 +92,7 @@ static void show_info_table(ryzen_access ry)
 	//get refresh table after adjust
 	int errorcode = refresh_table(ry);
 	if(errorcode){
-		printf("Unable to refresh power monitoring table: %d\n", errorcode);
+		printf("Unable to refresh power metric table: %d\n", errorcode);
 		return;
 	}
 


### PR DESCRIPTION
Added enable/disable OC commands
Added all core and per core OC commands
Added VID command (to set the correct voltage you must do (1.55 - [The VID you want, e.g. 1.25]) / 0.00625 otherwise, VID will lock to 1.55v)
Added PSMU message 0x31 to STAPM command to fix 25w max limit on the ASUS PN50/51
Added Lucienne to iGPU frequency command
Added per-core voltage, frequency, temperature, and power sensors
Added L3$ logic power, temperature, and frequency sensors
Added SoC voltage and power sensors
Added Fabric and memory frequency sensors
Added iGPU power, temperature, frequency, and voltage sensors
Added socket power sensor

Showcase of sensors added:
![Screenshot 2022-02-15 194024](https://user-images.githubusercontent.com/20888782/154136455-902bdb53-e278-4c0c-8866-755de98b6231.png)

