### PR TITLE
CPU overclocking support for unlocked APUs and additional sensors for Renoir/Lucienne/Cezanne/Barcelo/Van Gogh APUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Adjust power management settings for Ryzen Mobile Processors.
 
 Based on: [FlyGoat/ryzen_nb_smu](https://github.com/flygoat/ryzen_nb_smu)
 
-RyzenAdjUI_WPF by "JustSkill" is no longer maintained, for GUI please see [ryzen-controller-team/ryzen-controller](https://gitlab.com/ryzen-controller-team/ryzen-controller/).
+RyzenAdjUI_WPF by "JustSkill" is no longer maintained, for GUI please see  [AMD APU Tuning Utility](https://github.com/JamesCJ60/AMD-APU-Tuning-Utility) or [ryzen-controller-team/ryzen-controller](https://gitlab.com/ryzen-controller-team/ryzen-controller/).
 
 ## Usage
 The command line interface is identical on both Windows and Unix-Like OS.

--- a/lib/api.c
+++ b/lib/api.c
@@ -149,24 +149,25 @@ int request_table_ver_and_size(ryzen_access ry)
 
 	switch (ry->table_ver)
 	{
-		case 0x1E0001: ry->table_size = 0x568; break;
-		case 0x1E0002: ry->table_size = 0x580; break;
-		case 0x1E0003: ry->table_size = 0x578; break;
-		case 0x1E0004: ry->table_size = 0x608; break;
-		case 0x1E0005: ry->table_size = 0x608; break;
-		case 0x1E000A: ry->table_size = 0x608; break;
-		case 0x1E0101: ry->table_size = 0x608; break;
-		case 0x370000: ry->table_size = 0x794; break;
-		case 0x370001: ry->table_size = 0x884; break;
-		case 0x370002: ry->table_size = 0x88C; break;
-		case 0x370003: ry->table_size = 0x8AC; break;
-		case 0x370004: ry->table_size = 0x8AC; break;
-		case 0x370005: ry->table_size = 0x8C8; break;
-		case 0x400001: ry->table_size = 0x910; break;
-		case 0x400002: ry->table_size = 0x928; break;
-		case 0x400003: ry->table_size = 0x94C; break;
-		case 0x400004: ry->table_size = 0x944; break;
-		case 0x400005: ry->table_size = 0x944; break;
+	case 0x1E0001: ry->table_size = 0x568; break;
+	case 0x1E0002: ry->table_size = 0x580; break;
+	case 0x1E0003: ry->table_size = 0x578; break;
+	case 0x1E0004: ry->table_size = 0x608; break;
+	case 0x1E0005: ry->table_size = 0x608; break;
+	case 0x1E000A: ry->table_size = 0x608; break;
+	case 0x1E0101: ry->table_size = 0x608; break;
+	case 0x370000: ry->table_size = 0x794; break;
+	case 0x370001: ry->table_size = 0x884; break;
+	case 0x370002: ry->table_size = 0x88C; break;
+	case 0x370003: ry->table_size = 0x8AC; break;
+	case 0x370004: ry->table_size = 0x8AC; break;
+	case 0x370005: ry->table_size = 0x8C8; break;
+	case 0x400001: ry->table_size = 0x910; break;
+	case 0x400002: ry->table_size = 0x928; break;
+	case 0x400003: ry->table_size = 0x94C; break;
+	case 0x400004: ry->table_size = 0x944; break;
+	case 0x400005: ry->table_size = 0x944; break;
+	case 0x3F0000: ry->table_size = 0x7AC; break;
 		default:
 			//use a larger size then the largest known table to be able to test real table size of unknown tables
 			ry->table_size = 0xA00;
@@ -416,6 +417,7 @@ EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){
 	case FAM_VANGOGH:
 	case FAM_REMBRANDT:
 		_do_adjust(0x14);
+		_do_adjust_psmu(0x31);
 	}
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
@@ -871,6 +873,7 @@ EXP int CALL set_gfx_clk(ryzen_access ry, uint32_t value) {
 	switch (ry->family)
 	{
 	case FAM_RENOIR:
+	case FAM_LUCIENNE:
 		_do_adjust_psmu(0x89);
 		break;
 	}
@@ -917,6 +920,77 @@ EXP int CALL set_max_performance(ryzen_access ry) {
 	return ADJ_ERR_FAM_UNSUPPORTED;
 }
 
+EXP int CALL set_oc_clk(ryzen_access ry, uint32_t value) {
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x31);
+		_do_adjust_psmu(0x19);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_per_core_oc_clk(ryzen_access ry, uint32_t value) {
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x32);
+		_do_adjust_psmu(0x1a);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_oc_volt(ryzen_access ry, uint32_t value) {
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x33);
+		_do_adjust_psmu(0x1b);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_disable_oc(ryzen_access ry) {
+	uint32_t value = 0x0;
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x30);
+		_do_adjust_psmu(0x1d);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
+EXP int CALL set_enable_oc(ryzen_access ry) {
+	uint32_t value = 0x0;
+	switch (ry->family)
+	{
+	case FAM_LUCIENNE:
+	case FAM_RENOIR:
+	case FAM_CEZANNE:
+	case FAM_REMBRANDT:
+		_do_adjust(0x2F);
+		break;
+	}
+	return ADJ_ERR_FAM_UNSUPPORTED;
+}
+
 //PM Table section, offset of first lines are stable across multiple PM Table versions
 EXP float CALL get_stapm_limit(ryzen_access ry){_read_float_value(0x0);}
 EXP float CALL get_stapm_value(ryzen_access ry){_read_float_value(0x4);}
@@ -926,7 +1000,7 @@ EXP float CALL get_slow_limit(ryzen_access ry){_read_float_value(0x10);}
 EXP float CALL get_slow_value(ryzen_access ry){_read_float_value(0x14);}
 
 //custom section, offsets are depending on table version
-EXP float CALL get_apu_slow_limit(ryzen_access ry){
+EXP float CALL get_apu_slow_limit(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -940,11 +1014,12 @@ EXP float CALL get_apu_slow_limit(ryzen_access ry){
 	case 0x00400003:
 	case 0x00400004:
 	case 0x00400005:
+	case 0x003F0000: // Van Gogh
 		_read_float_value(0x18);
 	}
 	return NAN;
 }
-EXP float CALL get_apu_slow_value(ryzen_access ry){
+EXP float CALL get_apu_slow_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -958,11 +1033,12 @@ EXP float CALL get_apu_slow_value(ryzen_access ry){
 	case 0x00400003:
 	case 0x00400004:
 	case 0x00400005:
+	case 0x003F0000: // Van Gogh
 		_read_float_value(0x1C);
 	}
 	return NAN;
 }
-EXP float CALL get_vrm_current(ryzen_access ry){
+EXP float CALL get_vrm_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -988,7 +1064,7 @@ EXP float CALL get_vrm_current(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrm_current_value(ryzen_access ry){
+EXP float CALL get_vrm_current_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1014,7 +1090,7 @@ EXP float CALL get_vrm_current_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmsoc_current(ryzen_access ry){
+EXP float CALL get_vrmsoc_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1040,7 +1116,7 @@ EXP float CALL get_vrmsoc_current(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmsoc_current_value(ryzen_access ry){
+EXP float CALL get_vrmsoc_current_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1066,7 +1142,7 @@ EXP float CALL get_vrmsoc_current_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmmax_current(ryzen_access ry){
+EXP float CALL get_vrmmax_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1092,7 +1168,7 @@ EXP float CALL get_vrmmax_current(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmmax_current_value(ryzen_access ry){
+EXP float CALL get_vrmmax_current_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1118,7 +1194,7 @@ EXP float CALL get_vrmmax_current_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmsocmax_current(ryzen_access ry){
+EXP float CALL get_vrmsocmax_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1144,7 +1220,7 @@ EXP float CALL get_vrmsocmax_current(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_vrmsocmax_current_value(ryzen_access ry){
+EXP float CALL get_vrmsocmax_current_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1170,7 +1246,7 @@ EXP float CALL get_vrmsocmax_current_value(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_tctl_temp(ryzen_access ry){
+EXP float CALL get_tctl_temp(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1192,11 +1268,12 @@ EXP float CALL get_tctl_temp(ryzen_access ry){
 	case 0x00400003:
 	case 0x00400004:
 	case 0x00400005:
+	case 0x003F0000: // Van Gogh
 		_read_float_value(0x40);
 	}
 	return NAN;
 }
-EXP float CALL get_tctl_temp_value(ryzen_access ry){
+EXP float CALL get_tctl_temp_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1218,11 +1295,12 @@ EXP float CALL get_tctl_temp_value(ryzen_access ry){
 	case 0x00400003:
 	case 0x00400004:
 	case 0x00400005:
+	case 0x003F0000: // Van Gogh
 		_read_float_value(0x44);
 	}
 	return NAN;
 }
-EXP float CALL get_apu_skin_temp_limit(ryzen_access ry){
+EXP float CALL get_apu_skin_temp_limit(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -1236,11 +1314,12 @@ EXP float CALL get_apu_skin_temp_limit(ryzen_access ry){
 	case 0x00400003:
 	case 0x00400004:
 	case 0x00400005:
+	case 0x003F0000: // Van Gogh
 		_read_float_value(0x58);
 	}
 	return NAN;
 }
-EXP float CALL get_apu_skin_temp_value(ryzen_access ry){
+EXP float CALL get_apu_skin_temp_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -1254,11 +1333,12 @@ EXP float CALL get_apu_skin_temp_value(ryzen_access ry){
 	case 0x00400003:
 	case 0x00400004:
 	case 0x00400005:
+	case 0x003F0000: // Van Gogh
 		_read_float_value(0x5C);
 	}
 	return NAN;
 }
-EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry){
+EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -1276,7 +1356,7 @@ EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry){
 	}
 	return NAN;
 }
-EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry){
+EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x00370000:
@@ -1295,7 +1375,7 @@ EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry){
 	return NAN;
 }
 
-EXP float CALL get_psi0_current(ryzen_access ry){
+EXP float CALL get_psi0_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1322,7 +1402,7 @@ EXP float CALL get_psi0_current(ryzen_access ry){
 	return NAN;
 }
 
-EXP float CALL get_psi0soc_current(ryzen_access ry){
+EXP float CALL get_psi0soc_current(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1349,7 +1429,7 @@ EXP float CALL get_psi0soc_current(ryzen_access ry){
 	return NAN;
 }
 
-EXP float CALL get_cclk_setpoint(ryzen_access ry){
+EXP float CALL get_cclk_setpoint(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1377,7 +1457,7 @@ EXP float CALL get_cclk_setpoint(ryzen_access ry){
 	return NAN;
 }
 
-EXP float CALL get_cclk_busy_value(ryzen_access ry){
+EXP float CALL get_cclk_busy_value(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0001:
@@ -1442,7 +1522,7 @@ EXP float CALL get_stapm_time(ryzen_access ry)
 	return NAN;
 }
 
-EXP float CALL get_slow_time(ryzen_access ry){
+EXP float CALL get_slow_time(ryzen_access ry) {
 	switch (ry->table_ver)
 	{
 	case 0x001E0002:
@@ -1478,3 +1558,821 @@ EXP float CALL get_slow_time(ryzen_access ry){
 	return NAN;
 }
 
+EXP float CALL get_core_power(ryzen_access ry, uint32_t core) {
+	switch (core)
+	{
+	case 0:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x300);
+		case 0x00370005:
+			_read_float_value(0x31C);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x238); //568
+		case 0x00400001:
+			_read_float_value(0x304); //772
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x320); //800
+		}
+	case 1:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x304);
+		case 0x00370005:
+			_read_float_value(0x320);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x23C); //572
+		case 0x00400001:
+			_read_float_value(0x308); //776
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x324); //804
+		}
+	case 2:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x308);
+		case 0x00370005:
+			_read_float_value(0x324);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x240); //576
+		case 0x00400001:
+			_read_float_value(0x30c); //780
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x328); //808
+		}
+	case 3:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x30c);
+		case 0x00370005:
+			_read_float_value(0x328);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x244); //580
+		case 0x00400001:
+			_read_float_value(0x310); //784
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x32c); //812
+		}
+	case 4:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x310);
+		case 0x00370005:
+			_read_float_value(0x32c);
+		case 0x00400001:
+			_read_float_value(0x314); //788
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x330); //816
+		}
+
+	case 5:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x314);
+		case 0x00370005:
+			_read_float_value(0x330);
+		case 0x00400001:
+			_read_float_value(0x318); //792
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x334); //820
+		}
+	case 6:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x318);
+		case 0x00370005:
+			_read_float_value(0x334);
+		case 0x00400001:
+			_read_float_value(0x31c); //796
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x338); //824
+		}
+	case 7:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x31c);
+		case 0x00370005:
+			_read_float_value(0x338);
+		case 0x00400001:
+			_read_float_value(0x320); //800
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x33c); //828
+		}
+	}
+	return NAN;
+}
+
+EXP float CALL get_core_volt(ryzen_access ry, uint32_t core) {
+	switch (core)
+	{
+	case 0:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x320);
+		case 0x00370005:
+			_read_float_value(0x33C);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x248); //584
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x340); //832
+		}
+	case 1:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x324);
+		case 0x00370005:
+			_read_float_value(0x340);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x24C); //588
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x344); //836
+		}
+	case 2:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x328);
+		case 0x00370005:
+			_read_float_value(0x344);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x250); //592
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x348); //840
+		}
+	case 3:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x32C);
+		case 0x00370005:
+			_read_float_value(0x348);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x254); //596
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x34c); //844
+		}
+	case 4:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x330);
+		case 0x00370005:
+			_read_float_value(0x34C);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x350); //848
+
+		}
+	case 5:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x334);
+		case 0x00370005:
+			_read_float_value(0x350);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x354); //852
+		}
+	case 6:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x338);
+		case 0x00370005:
+			_read_float_value(0x354);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x358); //856
+		}
+	case 7:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x33C);
+		case 0x00370005:
+			_read_float_value(0x358);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x35c); //860
+		}
+	}
+	return NAN;
+}
+
+EXP float CALL get_core_temp(ryzen_access ry, uint32_t core) {
+	switch (core)
+	{
+	case 0:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x340);
+		case 0x00370005:
+			_read_float_value(0x35C);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x258); //600
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x360); //864
+		}
+	case 1:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x344);
+		case 0x00370005:
+			_read_float_value(0x360);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x25C); //604
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x364); //868
+		}
+	case 2:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x348);
+		case 0x00370005:
+			_read_float_value(0x364);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x260); //608
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x368); //872
+		}
+	case 3:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x34C);
+		case 0x00370005:
+			_read_float_value(0x368);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x264); //612
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x36c); //876
+		}
+	case 4:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x350);
+		case 0x00370005:
+			_read_float_value(0x36C);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x370); //880
+		}
+	case 5:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x354);
+		case 0x00370005:
+			_read_float_value(0x370);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x374); //884
+		}
+	case 6:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x358);
+		case 0x00370005:
+			_read_float_value(0x374);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x378); //888
+		}
+	case 7:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x35C);
+		case 0x00370005:
+			_read_float_value(0x378);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x37C); //892
+		}
+	}
+	return NAN;
+}
+
+EXP float CALL get_core_clk(ryzen_access ry, uint32_t core) {
+	switch (core)
+	{
+	case 0:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x3A0);
+		case 0x00370005:
+			_read_float_value(0x3BC);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x288); //648
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x3c0); //960
+		}
+	case 1:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x3A4);
+		case 0x00370005:
+			_read_float_value(0x3C0);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x2C8); //652
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x3c4); //964
+		}
+	case 2:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x3A8);
+		case 0x00370005:
+			_read_float_value(0x3C4);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x290); //656
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x3c8); //968
+		}
+	case 3:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x3AC);
+		case 0x00370005:
+			_read_float_value(0x3C8);
+		case 0x003F0000: // Van Gogh
+			_read_float_value(0x294); //660
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x3cc); //972
+		}
+	case 4:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x3B0);
+		case 0x00370005:
+			_read_float_value(0x3CC);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x3d0); //976
+		}
+	case 5:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x3B4);
+		case 0x00370005:
+			_read_float_value(0x3D0);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x3d4); //980
+		}
+	case 6:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x3B8);
+		case 0x00370005:
+			_read_float_value(0x3D4);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x3d8); //984
+		}
+	case 7:
+		switch (ry->table_ver)
+		{
+		case 0x00370000:
+		case 0x00370001:
+		case 0x00370002:
+		case 0x00370003:
+		case 0x00370004:
+			_read_float_value(0x3BC);
+		case 0x00370005:
+			_read_float_value(0x3D8);
+		case 0x00400004:
+		case 0x00400005:
+			_read_float_value(0x3dc); //988
+		}
+	}
+	return NAN;
+}
+
+EXP float CALL get_l3_clk(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x568);
+	case 0x00370005:
+		_read_float_value(0x584);
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x35C); //860
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x614); //1556
+	}
+	return NAN;
+}
+
+EXP float CALL get_l3_logic(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x540);
+	case 0x00370005:
+		_read_float_value(0x55C);
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x348); //840
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x600); //1536
+	}
+	return NAN;
+}
+
+EXP float CALL get_l3_vddm(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x548);
+	case 0x00370005:
+		_read_float_value(0x564);
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x34C); //844
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x604); //1540
+	}
+	return NAN;
+}
+
+EXP float CALL get_l3_temp(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x550);
+	case 0x00370005:
+		_read_float_value(0x56C);
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x350); //848
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x608); //1544
+	}
+	return NAN;
+}
+
+EXP float CALL get_gfx_clk(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x5B4);
+	case 0x00370005:
+		_read_float_value(0x5D0);
+	case 0x00400001:
+		_read_float_value(0x60C); //1548
+	case 0x00400002:
+		_read_float_value(0x624); //1572
+	case 0x00400003:
+		_read_float_value(0x644); //1604
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x648); //1608
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x388); //904
+	}
+	return NAN;
+}
+
+EXP float CALL get_gfx_volt(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x5A8);
+	case 0x00370005:
+		_read_float_value(0x5C4);
+	case 0x00400001:
+		_read_float_value(0x600); //1536
+	case 0x00400002:
+		_read_float_value(0x618); //1560
+	case 0x00400003:
+		_read_float_value(0x638); //1592
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x63C); //1596
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x37C); //896
+	}
+	return NAN;
+}
+
+EXP float CALL get_gfx_temp(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x5AC);
+	case 0x00370005:
+		_read_float_value(0x5C8);
+	case 0x00400001:
+		_read_float_value(0x604); //1540
+	case 0x00400002:
+		_read_float_value(0x61C); //1564
+	case 0x00400003:
+		_read_float_value(0x63C); //1596
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x640); //1600
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x380); //896
+	}
+	return NAN;
+}
+
+EXP float CALL get_fclk(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x5CC);
+	case 0x00370005:
+		_read_float_value(0x5E8);
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x3C5); //956
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x664); //1636
+	}
+	return NAN;
+}
+
+EXP float CALL get_mem_clk(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x5D4);
+	case 0x00370005:
+		_read_float_value(0x5F0);
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x3C4); //964
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x66c); //1644
+	}
+	return NAN;
+}
+
+EXP float CALL get_soc_volt(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x198);
+	case 0x00370005:
+		_read_float_value(0x198);
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x1A0); //416
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x19c); //412
+
+	}
+	return NAN;
+}
+
+EXP float CALL get_soc_power(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+		_read_float_value(0x1A0);
+	case 0x00370005:
+		_read_float_value(0x1A0);
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0x1A8); //424
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x1a4); //420
+	}
+	return NAN;
+}
+
+EXP float CALL get_socket_power(ryzen_access ry) {
+	switch (ry->table_ver)
+	{
+	case 0x00370000:
+	case 0x00370001:
+	case 0x00370002:
+	case 0x00370003:
+	case 0x00370004:
+	case 0x00370005:
+		_read_float_value(0x98);
+	case 0x00400001:
+	case 0x00400002:
+	case 0x00400003:
+	case 0x00400004:
+	case 0x00400005:
+		_read_float_value(0x98); //152
+	case 0x003F0000: //Van Gogh
+		_read_float_value(0xA8); //168
+	}
+	return NAN;
+}

--- a/main.c
+++ b/main.c
@@ -188,7 +188,7 @@ int main(int argc, const char **argv)
 	int err = 0;
 
 	int info = 0, dump_table = 0, any_adjust_applied = 0;
-	int power_saving = 0, max_performance = 0;
+	int power_saving = 0, max_performance = 0, enable_oc = 0x0, disable_oc = 0x0;
 	//init unsigned types with max value because we treat max value as unset
 	uint32_t stapm_limit = -1, fast_limit = -1, slow_limit = -1, slow_time = -1, stapm_time = -1, tctl_temp = -1;
 	uint32_t vrm_current = -1, vrmsoc_current = -1, vrmmax_current = -1, vrmsocmax_current = -1, psi0_current = -1, psi0soc_current = -1;
@@ -196,7 +196,7 @@ int main(int argc, const char **argv)
 	uint32_t max_socclk_freq = -1, min_socclk_freq = -1, max_fclk_freq = -1, min_fclk_freq = -1, max_vcn = -1, min_vcn = -1, max_lclk = -1, min_lclk = -1;
 	uint32_t max_gfxclk_freq = -1, min_gfxclk_freq = -1, prochot_deassertion_ramp = -1, apu_skin_temp_limit = -1, dgpu_skin_temp_limit = -1, apu_slow_limit = -1;
 	uint32_t skin_temp_power_limit = -1;
-	uint32_t gfx_clk = -1;
+	uint32_t gfx_clk = -1, oc_clk = -1, oc_volt = -1;
 
 	//create structure for parseing
 	struct argparse_option options[] = {
@@ -238,6 +238,10 @@ int main(int argc, const char **argv)
 		OPT_U32('\0', "apu-slow-limit", &apu_slow_limit, "APU PPT Slow Power limit for A+A dGPU platform - PPT LIMIT APU (mW)"),
 		OPT_U32('\0', "skin-temp-limit", &skin_temp_power_limit, "Skin Temperature Power Limit (mW)"),
 		OPT_U32('\0', "gfx-clk", &gfx_clk, "Forced Clock Speed MHz (Renoir Only)"),
+		OPT_U32('\0', "oc-clk", &oc_clk, "Forced Core Clock Speed MHz (Renoir and up Only)"),
+		OPT_U32('\0', "oc-volt", &oc_volt, "Forced Core VID: Must follow this calcuation (1.55 - [VID you want to set e.g. 1.25 for 1.25v]) / 0.00625 (Renoir and up Only)"),
+		OPT_BOOLEAN('\0', "enable-oc", &enable_oc, "Enable OC (Renoir and up Only)"),
+		OPT_BOOLEAN('\0', "disable-oc", &disable_oc, "Enable OC (Renoir and up Only)"),
 		OPT_BOOLEAN('\0', "power-saving", &power_saving, "Hidden options to improve power efficiency (is set when AC unplugged): behavior depends on CPU generation, Device and Manufacture"),
 		OPT_BOOLEAN('\0', "max-performance", &max_performance, "Hidden options to improve performance (is set when AC plugged in): behavior depends on CPU generation, Device and Manufacture"),
 		OPT_GROUP("P-State Functions"),
@@ -305,8 +309,12 @@ int main(int argc, const char **argv)
 	_do_adjust(apu_slow_limit);
 	_do_adjust(skin_temp_power_limit);
 	_do_adjust(gfx_clk);
+	_do_adjust(oc_clk);
+	_do_adjust(oc_volt);
 	_do_enable(power_saving);
 	_do_enable(max_performance);
+	_do_enable(enable_oc)
+	_do_enable(disable_oc);
 
 	if (!err) {
 		//call show table dump before anybody did call table refresh, because we want to copy the old values first


### PR DESCRIPTION
Added enable/disable OC commands
Added all core and per core OC commands
Added VID command (to set the correct voltage you must do (1.55 - [The VID you want, e.g. 1.25]) / 0.00625 otherwise, VID will lock to 1.55v)
Added PSMU message 0x31 to STAPM command to fix 25w max limit on the ASUS PN50/51
Added Lucienne to iGPU frequency command
Added per-core voltage, frequency, temperature, and power sensors
Added L3$ logic power, temperature, and frequency sensors
Added SoC voltage and power sensors
Added Fabric and memory frequency sensors
Added iGPU power, temperature, frequency, and voltage sensors
Added socket power sensor

Showcase of sensors added:
![image](https://user-images.githubusercontent.com/20888782/154824830-3c3f1044-7726-48ff-a173-60d81f37aab3.png)