### PR TITLE
Allow to use CO in readjustService.ps1 

### DIFF
--- a/win32/readjustService.ps1
+++ b/win32/readjustService.ps1
@@ -35,6 +35,7 @@ function doAdjust_ACmode {
     $Script:repeatWaitTimeSeconds = 1    #only use values below 5s if you are using $monitorField
     adjust "fast_limit" 46000
     adjust "slow_limit" 25000
+    #adjust "slow_time" 30
     #adjust "coall" 4294967266    #Curve optimizer at -30
     #adjust "tctl_temp" 93
     #adjust "apu_skin_temp_limit" 50

--- a/win32/readjustService.ps1
+++ b/win32/readjustService.ps1
@@ -35,7 +35,7 @@ function doAdjust_ACmode {
     $Script:repeatWaitTimeSeconds = 1    #only use values below 5s if you are using $monitorField
     adjust "fast_limit" 46000
     adjust "slow_limit" 25000
-    #adjust "slow_time" 30
+    #adjust "coall" 4294967266    #Curve optimizer at -30
     #adjust "tctl_temp" 93
     #adjust "apu_skin_temp_limit" 50
     #adjust "vrmmax_current" 100000
@@ -106,6 +106,9 @@ $apiHeader = @'
 [DllImport("libryzenadj.dll")] public static extern int set_apu_skin_temp_limit(IntPtr ry, [In]uint value);
 [DllImport("libryzenadj.dll")] public static extern int set_dgpu_skin_temp_limit(IntPtr ry, [In]uint value);
 [DllImport("libryzenadj.dll")] public static extern int set_apu_slow_limit(IntPtr ry, [In]uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_coall(IntPtr ry, [In]uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_coper(IntPtr ry, [In]uint value);
+[DllImport("libryzenadj.dll")] public static extern int set_cogfx(IntPtr ry, [In]uint value);
 [DllImport("libryzenadj.dll")] public static extern int set_power_saving(IntPtr ry);
 [DllImport("libryzenadj.dll")] public static extern int set_max_performance(IntPtr ry);
 


### PR DESCRIPTION
`set_coall`, `set_coper` and `set_cogfx` were not imported from libryzenadj.dll, calls from readjustService.ps1 would result in "Method invocation failed" error. This should fix it. 