### PR TITLE
Add Dragon Range based CPU support

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -1149,8 +1149,12 @@ EXP int CALL set_coall(ryzen_access ry, uint32_t value) {
 	case FAM_LUCIENNE:
 		_do_adjust(0x55);
 		break;
+	case FAM_VANGOGH:
 	case FAM_REMBRANDT:
 		_do_adjust(0x4C);
+		break;
+	case FAM_DRAGON_RANGE:
+		_do_adjust_psmu(0x7);
 		break;
 	}
 	return err;
@@ -1165,8 +1169,13 @@ EXP int CALL set_coper(ryzen_access ry, uint32_t value) {
 	case FAM_RENOIR:
 	case FAM_LUCIENNE:
 		_do_adjust(0x54);
+		break;
+	case FAM_VANGOGH:
 	case FAM_REMBRANDT:
 		_do_adjust(0x4B);
+		break;
+	case FAM_DRAGON_RANGE:
+		_do_adjust_psmu(0x6);
 		break;
 	}
 	return err;
@@ -1188,6 +1197,55 @@ EXP int CALL set_cogfx(ryzen_access ry, uint32_t value) {
 	}
 	return err;
 }
+
+EXP int CALL set_ppt(ryzen_access ry, uint32_t value) {
+	int err = ADJ_ERR_FAM_UNSUPPORTED;
+
+	switch (ry->family)
+	{
+	case FAM_DRAGON_RANGE:
+		_do_adjust_psmu(0x56);
+		break;
+	}
+	return err;
+}
+
+EXP int CALL set_tdc(ryzen_access ry, uint32_t value) {
+	int err = ADJ_ERR_FAM_UNSUPPORTED;
+
+	switch (ry->family)
+	{
+	case FAM_DRAGON_RANGE:
+		_do_adjust_psmu(0x57);
+		break;
+	}
+	return err;
+}
+
+EXP int CALL set_edc(ryzen_access ry, uint32_t value) {
+	int err = ADJ_ERR_FAM_UNSUPPORTED;
+
+	switch (ry->family)
+	{
+	case FAM_DRAGON_RANGE:
+		_do_adjust_psmu(0x58);
+		break;
+	}
+	return err;
+}
+
+EXP int CALL set_htc(ryzen_access ry, uint32_t value) {
+	int err = ADJ_ERR_FAM_UNSUPPORTED;
+
+	switch (ry->family)
+	{
+	case FAM_DRAGON_RANGE:
+		_do_adjust_psmu(0x59);
+		break;
+	}
+	return err;
+}
+
 
 //PM Table section, offset of first lines are stable across multiple PM Table versions
 EXP float CALL get_stapm_limit(ryzen_access ry){_read_float_value(0x0);}

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -17,7 +17,7 @@
 static void getcpuid(unsigned int CPUInfo[4], unsigned int InfoType)
 {
 #if defined(__GNUC__)
-    __cpuid(InfoType, CPUInfo[0],CPUInfo[1],CPUInfo[2],CPUInfo[3]);
+    __cpuid(InfoType, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #elif defined(_WIN32)
     __cpuid((int*)(void*)CPUInfo, (int)InfoType);
 #endif
@@ -34,9 +34,9 @@ static enum ryzen_family cpuid_load_family()
     getcpuid(regs, 0);
 
     /* Hack Alert! Put into str buffer */
-    *(uint32_t *) &vendor[0] = regs[1];
-    *(uint32_t *) &vendor[4] = regs[3];
-    *(uint32_t *) &vendor[8] = regs[2];
+    *(uint32_t*)&vendor[0] = regs[1];
+    *(uint32_t*)&vendor[4] = regs[3];
+    *(uint32_t*)&vendor[8] = regs[2];
 
     if (strncmp(vendor, CPUID_VENDOR_AMD, strlen(CPUID_VENDOR_AMD))) {
         printf("Not AMD processor, must be kidding\n");
@@ -78,6 +78,8 @@ static enum ryzen_family cpuid_load_family()
         case 64:
         case 68:
             return FAM_REMBRANDT;
+        case 97:
+            return FAM_DRAGON_RANGE;
         case 116:
             return FAM_PHEONIX;
         default:

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -25,6 +25,7 @@ enum ryzen_family {
         FAM_REMBRANDT,
         FAM_MENDOCINO,
         FAM_PHEONIX,
+        FAM_DRAGON_RANGE,
         FAM_END
 };
 
@@ -116,6 +117,10 @@ EXP int CALL set_max_performance(ryzen_access ry);
 EXP int CALL set_coall(ryzen_access ry, uint32_t value);
 EXP int CALL set_coper(ryzen_access ry, uint32_t value);
 EXP int CALL set_cogfx(ryzen_access ry, uint32_t value);
+EXP int CALL set_ppt(ryzen_access ry, uint32_t value);
+EXP int CALL set_tdc(ryzen_access ry, uint32_t value);
+EXP int CALL set_edc(ryzen_access ry, uint32_t value);
+EXP int CALL set_htc(ryzen_access ry, uint32_t value);
 
 EXP float CALL get_stapm_limit(ryzen_access ry);
 EXP float CALL get_stapm_value(ryzen_access ry);

--- a/main.c
+++ b/main.c
@@ -190,8 +190,8 @@ int main(int argc, const char **argv)
 	int info = 0, dump_table = 0, any_adjust_applied = 0;
 	int power_saving = 0, max_performance = 0, enable_oc = 0x0, disable_oc = 0x0;
 	//init unsigned types with max value because we treat max value as unset
-	uint32_t stapm_limit = -1, fast_limit = -1, slow_limit = -1, slow_time = -1, stapm_time = -1, tctl_temp = -1;
-	uint32_t vrm_current = -1, vrmsoc_current = -1, vrmmax_current = -1, vrmsocmax_current = -1, psi0_current = -1, psi0soc_current = -1;
+	uint32_t stapm_limit = -1, fast_limit = -1, slow_limit = -1, slow_time = -1, stapm_time = -1, tctl_temp = -1, ppt = -1, htc = -1;
+	uint32_t vrm_current = -1, vrmsoc_current = -1, vrmmax_current = -1, vrmsocmax_current = -1, psi0_current = -1, psi0soc_current = -1, tdc = -1, edc = -1;
 	uint32_t vrmgfx_current = -1, vrmcvip_current = -1, vrmgfxmax_current = -1, psi3cpu_current = -1, psi3gfx_current = -1;
 	uint32_t max_socclk_freq = -1, min_socclk_freq = -1, max_fclk_freq = -1, min_fclk_freq = -1, max_vcn = -1, min_vcn = -1, max_lclk = -1, min_lclk = -1;
 	uint32_t max_gfxclk_freq = -1, min_gfxclk_freq = -1, prochot_deassertion_ramp = -1, apu_skin_temp_limit = -1, dgpu_skin_temp_limit = -1, apu_slow_limit = -1;
@@ -245,6 +245,10 @@ int main(int argc, const char **argv)
 		OPT_U32('\0', "set-coall", &coall, "All core Curve Optimiser"),
 		OPT_U32('\0', "set-coper", &coper, "Per core Curve Optimiser"),
 		OPT_U32('\0', "set-cogfx", &cogfx, "iGPU Curve Optimiser"),
+	    OPT_U32('\0', "set-ppt", &ppt, "PPT limit for chiplet based mobile CPUs"),
+		OPT_U32('\0', "set-tdc", &tdc, "TDC limit for chiplet based mobile CPUs"),
+		OPT_U32('\0', "set-edc", &edc, "EDC limit for chiplet based mobile CPUs"),
+		OPT_U32('\0', "set-htc", &htc, "Thermal limit for chiplet based mobile CPUs"),
 		OPT_BOOLEAN('\0', "power-saving", &power_saving, "Hidden options to improve power efficiency (is set when AC unplugged): behavior depends on CPU generation, Device and Manufacture"),
 		OPT_BOOLEAN('\0', "max-performance", &max_performance, "Hidden options to improve performance (is set when AC plugged in): behavior depends on CPU generation, Device and Manufacture"),
 		OPT_GROUP("P-State Functions"),
@@ -321,6 +325,10 @@ int main(int argc, const char **argv)
 	_do_adjust(coall);
 	_do_adjust(coper);
 	_do_adjust(cogfx);
+	_do_adjust(ppt);
+	_do_adjust(tdc);
+	_do_adjust(edc);
+	_do_adjust(htc);
 
 	if (!err) {
 		//call show table dump before anybody did call table refresh, because we want to copy the old values first


### PR DESCRIPTION
This adds the ability to set PPT, TDC, EDC, Curve Optimiser and HTC limits on Dragon Range (7045HX) based laptops. These changes can also be used for Raphael support for the above options.