### PR TITLE
added Linux compile and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ We did provide some examples for automation. And these require configuration dur
 Because it is very easy to build the latest version of RyzenAdj on Linux, we don't provide precompiled packages for distributions.
 Just follow the build instructions and you are ready to use it.
 
+```
+git clone https://github.com/FlyGoat/RyzenAdj.git
+cd RyzenAdj
+rm -r win32
+cmake .
+make
+ln -S ryzenadj ~/.local/bin/ryzenadj
+ln -S ryzenadj ~/.bin/ryzenadj
+```
+
+
 ### Windows Installation
 
 Before you start installing anything, it is highly recommended getting familiar with RyzenAdj to find out what can be done on your device.

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ cd RyzenAdj
 rm -r win32
 cmake .
 make
-ln -S ryzenadj ~/.local/bin/ryzenadj
-ln -S ryzenadj ~/.bin/ryzenadj
+if [ -d "~/.local/bin" ]; then ln -s ryzenadj ~/.local/bin/ryzenadj && echo "symlinked to ~/.local/bin/ryzenadj"
+if [ -d "~/.bin" ]; then ln -s ryzenadj ~/.bin/ryzenadj && echo "symlinked to ~/.bin/ryzenadj"
 ```
 
 


### PR DESCRIPTION
I could not find compile instructions and for me "just compile it" is not easy, I think this should be correct?

I personally have `~/.bin` in my path, but I think standard is `~/.local/bin`, even though thats used for pip files.

Removed the windows dir, dont think its needed.

Everything in one directory, maybe better to have it in a build directory? But I am a beginner and did not find a way to do that.