### PR TITLE
Add Curve Optimiser support for Phoenix

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -1159,6 +1159,7 @@ EXP int CALL set_coall(ryzen_access ry, uint32_t value) {
 		break;
 	case FAM_REMBRANDT:
 	case FAM_VANGOGH:
+	case FAM_PHOENIX:
 		_do_adjust(0x4C);
 		break;
 	}


### PR DESCRIPTION
The all core curve optimizer works also for Phoenix apu and can be easily enabled with this simple change. Tested on 7940HS