### PR TITLE
Extend Van Gogh family to include Sephiroth APU Revision.

### DIFF
--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -62,6 +62,7 @@ static enum ryzen_family cpuid_load_family()
         case 104:
             return FAM_LUCIENNE;
         case 144:
+        case 145:
             return FAM_VANGOGH;
         case 160:
             return FAM_MENDOCINO;


### PR DESCRIPTION
Van Gogh functionality appears unchanged in the new Sephiroth APU revision used by Steam Deck Oled.

Specifically tested Curve optimizer (--set-coall) which functions well, and --set-cogfx which continues to be silently accepted by SMU but doesn't appear to do anything, consistent with Aerith behaviour.