### PR TITLE
Improve monitorField target value calculation

### DIFF
--- a/win32/readjustService.ps1
+++ b/win32/readjustService.ps1
@@ -197,7 +197,9 @@ if($ry -eq 0){
 
 function adjust ([String] $fieldName, [uInt32] $value) {
     if($fieldName -eq $Script:monitorField) {
-        $newTargetValue = [math]::round($value * 0.001, 3, 0)
+        # Adjust target value to the unit of measurement of return value of RyzenAdj
+        $multiplier = if($value -gt 2000) { 0.001 } else { 1 }
+        $newTargetValue = [math]::round($value * $multiplier, 3, 0)
         if($Script:monitorFieldAdjTarget -ne $newTargetValue){
             $Script:monitorFieldAdjTarget = $newTargetValue
             Write-Host "set new monitoring target $fieldName to $newTargetValue"


### PR DESCRIPTION
The `monitorField` target value calculation now uses heuristic method to convert the target value to the appropriate unit of measurement, that RyzenAdj uses to return value in.

E.g. `fast_limit` will be divided by 1000, as RyzenAdj sets the value in milliwatts (e.g. 25000), while returns the value in watts (e.g. 25). But `tctl_temp` will not be divided by 1000, as RyzenAdj sets the value in degrees Celsius (e.g. 85) and returns the value also in degrees Celsius (e.g. 85).

Fixes #286 

@Falcosc I'm not sure why did you select exactly value 2000 for this heuristic detection, so feel free to improve the commit message with the explanation.