### PR TITLE
Add OpenSUSE Tumbleweed instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ On Arch:
 
     sudo pacman -S base-devel pciutils cmake
 
+
+On OpenSUSE Tumbleweed:
+
+    sudo zypper in cmake gcc14-c++ pciutils-devel
+
+You may need to add the `iomem=relaxed` param to your kernel params on Tumbleweed, or [you may run into errors at runtime](https://github.com/FlyGoat/RyzenAdj/issues/241). 
+
 If your Distribution is not supported, try finding the packages or use [Distrobox](https://github.com/89luca89/distrobox) or [Toolbox](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/) instead.
 
 The simplest way to build it:


### PR DESCRIPTION
This minor PR adds the build dependencies for OpenSUSE Tumbleweed to the `README`, and also a workaround to an issue with that distro.