### PR TITLE
Add support for Strix Halo CPUs

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -140,6 +140,7 @@ static int request_table_ver_and_size(ryzen_access ry)
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		get_table_ver_msg = 0x6;
 		break;
 	default:
@@ -175,9 +176,10 @@ static int request_table_ver_and_size(ryzen_access ry)
 	case 0x450004: ry->table_size = 0xA44; break;
 	case 0x450005: ry->table_size = 0xA44; break;
 	case 0x4C0006: ry->table_size = 0xAA0; break;
+	case 0x64020c: ry->table_size = 0xE50; break;
 		default:
 			//use a larger size then the largest known table to be able to test real table size of unknown tables
-			ry->table_size = 0xA00;
+			ry->table_size = 0x1000;
 	}
 
 	if (resp != REP_MSG_OK) {
@@ -210,6 +212,7 @@ static int request_table_addr(ryzen_access ry)
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		get_table_addr_msg = 0x66;
 		break;
 	default:
@@ -225,6 +228,7 @@ static int request_table_addr(ryzen_access ry)
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		ry->table_addr = (uint64_t) args.arg1 << 32 | args.arg0;
 		break;
 	default:
@@ -261,6 +265,7 @@ static int request_transfer_table(ryzen_access ry)
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		transfer_table_msg = 0x65;
 		break;
 	default:
@@ -452,6 +457,7 @@ EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x14);
         if (err) {
             printf("%s: Retry with PSMU\n", __func__);
@@ -483,6 +489,7 @@ EXP int CALL set_fast_limit(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x15);
 	default:
 		break;
@@ -511,6 +518,7 @@ EXP int CALL set_slow_limit(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x16);
 	default:
 		break;
@@ -539,6 +547,7 @@ EXP int CALL set_slow_time(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x17);
 	default:
 		break;
@@ -567,6 +576,7 @@ EXP int CALL set_stapm_time(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x18);
 	default:
 		break;
@@ -595,6 +605,7 @@ EXP int CALL set_tctl_temp(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x19);
 	default:
 		break;
@@ -623,6 +634,7 @@ EXP int CALL set_vrm_current(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x1a);
 	default:
 		break;
@@ -651,6 +663,7 @@ EXP int CALL set_vrmsoc_current(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x1b);
 	default:
 		break;
@@ -704,6 +717,7 @@ EXP int CALL set_vrmmax_current(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x1c);
 		break;
 	case FAM_VANGOGH:
@@ -747,6 +761,7 @@ EXP int CALL set_vrmsocmax_current(ryzen_access ry, uint32_t value){
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x1d);
 	default:
 		break;
@@ -1007,6 +1022,7 @@ EXP int CALL set_prochot_deassertion_ramp(ryzen_access ry, uint32_t value) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x1f);
 	default:
 		break;
@@ -1059,6 +1075,7 @@ EXP int CALL set_dgpu_skin_temp_limit(ryzen_access ry, uint32_t value) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x34);
 		break;
 	default:
@@ -1083,6 +1100,7 @@ EXP int CALL set_apu_slow_limit(ryzen_access ry, uint32_t value) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x23);
 		break;
 	default:
@@ -1109,6 +1127,7 @@ EXP int CALL set_skin_temp_power_limit(ryzen_access ry, uint32_t value) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x4a);
 		break;
 	default:
@@ -1160,6 +1179,7 @@ EXP int CALL set_power_saving(ryzen_access ry) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x12);
 		break;
 	default:
@@ -1190,6 +1210,7 @@ EXP int CALL set_max_performance(ryzen_access ry) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x11);
 		break;
 	default:
@@ -1318,6 +1339,7 @@ EXP int CALL set_coall(ryzen_access ry, uint32_t value) {
 	case FAM_VANGOGH:
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
+	case FAM_STRIXHALO:
 		_do_adjust(0x4C);
 		break;
 	default:
@@ -1362,6 +1384,7 @@ EXP int CALL set_cogfx(ryzen_access ry, uint32_t value) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_VANGOGH:
+	case FAM_STRIXHALO:	
 		_do_adjust_psmu(0xB7);
 		break;
 	default:
@@ -1703,6 +1726,7 @@ EXP float CALL get_tctl_temp(ryzen_access ry) {
 	case 0x001E0005:
 	case 0x001E000A:
 	case 0x001E0101:
+	case 0x0064020c:	
 		_read_float_value(0x58); //use core1 because core0 is not reported on dual core cpus
 	case 0x00370000:
 	case 0x00370001:
@@ -1737,6 +1761,7 @@ EXP float CALL get_tctl_temp_value(ryzen_access ry) {
 	case 0x001E0005:
 	case 0x001E000A:
 	case 0x001E0101:
+	case 0x0064020c:
 		_read_float_value(0x5C); //use core1 because core0 is not reported on dual core cpus
 	case 0x00370000:
 	case 0x00370001:
@@ -1781,6 +1806,7 @@ EXP float CALL get_apu_skin_temp_limit(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x0064020c:
 		_read_float_value(0x58);
 	default:
 		break;
@@ -1807,6 +1833,7 @@ EXP float CALL get_apu_skin_temp_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x0064020c:
 		_read_float_value(0x5C);
 	default:
 		break;
@@ -1832,6 +1859,7 @@ EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x0064020c:	
 		_read_float_value(0x60);
 	default:
 		break;
@@ -1857,6 +1885,7 @@ EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x0064020c:	
 		_read_float_value(0x64);
 	default:
 		break;
@@ -2072,11 +2101,11 @@ EXP float CALL get_slow_time(ryzen_access ry) {
 }
 
 EXP float CALL get_core_power(ryzen_access ry, uint32_t core) {
-	if (core > 7)
+	if (core > 15)
 		return NAN;
 	
 	u32 baseOffset;
-	
+	// kevin 0x104 might be power, 16 entries
 	switch (ry->table_ver) {
 		case 0x00370000:
 		case 0x00370001:
@@ -2102,6 +2131,9 @@ EXP float CALL get_core_power(ryzen_access ry, uint32_t core) {
 		case 0x00400005:
 			baseOffset = 0x320;
 			break;
+		case 0x0064020c: // Strix Halo
+			baseOffset = 0xB90;
+			break;
 		default:
 			return NAN;
 	}
@@ -2110,11 +2142,11 @@ EXP float CALL get_core_power(ryzen_access ry, uint32_t core) {
 }
 
 EXP float CALL get_core_volt(ryzen_access ry, uint32_t core) {
-	if (core > 7)
+	if (core > 15)
 		return NAN;
 	
 	u32 baseOffset;
-
+	// kevinh 0x1cc - 17 entries?
 	switch (ry->table_ver) {
 		case 0x00370000:
 		case 0x00370001:
@@ -2137,6 +2169,9 @@ EXP float CALL get_core_volt(ryzen_access ry, uint32_t core) {
 		case 0x00400005:
 			baseOffset = 0x340;
 			break;
+		case 0x0064020c: // Strix Halo
+			baseOffset = 0xBD0;
+			break;
 		default:
 			return NAN;
 	}
@@ -2145,7 +2180,7 @@ EXP float CALL get_core_volt(ryzen_access ry, uint32_t core) {
 }
 
 EXP float CALL get_core_temp(ryzen_access ry, uint32_t core) {
-	if (core > 7)
+	if (core > 15)
 		return NAN;
 	
 	u32 baseOffset;
@@ -2171,6 +2206,9 @@ EXP float CALL get_core_temp(ryzen_access ry, uint32_t core) {
 		case 0x00400004:
 		case 0x00400005:
 			baseOffset = 0x360;
+			break;
+		case 0x0064020c: // Strix Halo
+			baseOffset = 0xC10;
 			break;
 		default:
 			return NAN;

--- a/lib/api.c
+++ b/lib/api.c
@@ -2072,6 +2072,9 @@ EXP float CALL get_slow_time(ryzen_access ry) {
 }
 
 EXP float CALL get_core_power(ryzen_access ry, uint32_t core) {
+	if (core > 7)
+		return NAN;
+	
 	u32 baseOffset;
 	
 	switch (ry->table_ver) {
@@ -2107,6 +2110,9 @@ EXP float CALL get_core_power(ryzen_access ry, uint32_t core) {
 }
 
 EXP float CALL get_core_volt(ryzen_access ry, uint32_t core) {
+	if (core > 7)
+		return NAN;
+	
 	u32 baseOffset;
 
 	switch (ry->table_ver) {
@@ -2139,6 +2145,9 @@ EXP float CALL get_core_volt(ryzen_access ry, uint32_t core) {
 }
 
 EXP float CALL get_core_temp(ryzen_access ry, uint32_t core) {
+	if (core > 7)
+		return NAN;
+	
 	u32 baseOffset;
 
 	switch (ry->table_ver) {
@@ -2171,6 +2180,9 @@ EXP float CALL get_core_temp(ryzen_access ry, uint32_t core) {
 }
 
 EXP float CALL get_core_clk(ryzen_access ry, uint32_t core) {
+	if (core > 7)
+		return NAN;
+	
 	u32 baseOffset;
 
 	switch (ry->table_ver) {

--- a/lib/api.c
+++ b/lib/api.c
@@ -2139,156 +2139,35 @@ EXP float CALL get_core_volt(ryzen_access ry, uint32_t core) {
 }
 
 EXP float CALL get_core_temp(ryzen_access ry, uint32_t core) {
-	switch (core)
-	{
-	case 0:
-		switch (ry->table_ver)
-		{
+	u32 baseOffset;
+
+	switch (ry->table_ver) {
 		case 0x00370000:
 		case 0x00370001:
 		case 0x00370002:
 		case 0x00370003:
 		case 0x00370004:
-			_read_float_value(0x340);
+			baseOffset = 0x340;
+			break;
 		case 0x00370005:
-			_read_float_value(0x35C);
-		case 0x003F0000: // Van Gogh
-			_read_float_value(0x258); //600
+			baseOffset = 0x35C;
+			break;
+		case 0x003F0000: { // Van Gogh
+			if (core >= 4)
+				return NAN;
+
+			baseOffset = 0x258;
+		}
+			break;
 		case 0x00400004:
 		case 0x00400005:
-			_read_float_value(0x360); //864
-	default:
-		break;
+			baseOffset = 0x360;
+			break;
+		default:
+			return NAN;
 	}
-	case 1:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x344);
-		case 0x00370005:
-			_read_float_value(0x360);
-		case 0x003F0000: // Van Gogh
-			_read_float_value(0x25C); //604
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x364); //868
-	default:
-		break;
-	}
-	case 2:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x348);
-		case 0x00370005:
-			_read_float_value(0x364);
-		case 0x003F0000: // Van Gogh
-			_read_float_value(0x260); //608
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x368); //872
-	default:
-		break;
-	}
-	case 3:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x34C);
-		case 0x00370005:
-			_read_float_value(0x368);
-		case 0x003F0000: // Van Gogh
-			_read_float_value(0x264); //612
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x36c); //876
-	default:
-		break;
-	}
-	case 4:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x350);
-		case 0x00370005:
-			_read_float_value(0x36C);
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x370); //880
-	default:
-		break;
-	}
-	case 5:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x354);
-		case 0x00370005:
-			_read_float_value(0x370);
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x374); //884
-	default:
-		break;
-	}
-	case 6:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x358);
-		case 0x00370005:
-			_read_float_value(0x374);
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x378); //888
-	default:
-		break;
-	}
-	case 7:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x35C);
-		case 0x00370005:
-			_read_float_value(0x378);
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x37C); //892
-	default:
-		break;
-	}
-	default:
-		break;
-	}
-	return NAN;
+
+	_read_float_value(baseOffset + (core * 4));
 }
 
 EXP float CALL get_core_clk(ryzen_access ry, uint32_t core) {

--- a/lib/api.c
+++ b/lib/api.c
@@ -2171,156 +2171,35 @@ EXP float CALL get_core_temp(ryzen_access ry, uint32_t core) {
 }
 
 EXP float CALL get_core_clk(ryzen_access ry, uint32_t core) {
-	switch (core)
-	{
-	case 0:
-		switch (ry->table_ver)
-		{
+	u32 baseOffset;
+
+	switch (ry->table_ver) {
 		case 0x00370000:
 		case 0x00370001:
 		case 0x00370002:
 		case 0x00370003:
 		case 0x00370004:
-			_read_float_value(0x3A0);
+			baseOffset = 0x3A0;
+			break;
 		case 0x00370005:
-			_read_float_value(0x3BC);
-		case 0x003F0000: // Van Gogh
-			_read_float_value(0x288); //648
+			baseOffset = 0x3BC;
+			break;
+		case 0x003F0000: { // Van Gogh
+			if (core >= 4)
+				return NAN;
+			
+			baseOffset = 0x288;
+		}
+			break;
 		case 0x00400004:
 		case 0x00400005:
-			_read_float_value(0x3c0); //960
-	default:
-		break;
+			baseOffset = 0x3c0;
+			break;
+		default:
+			return NAN;
 	}
-	case 1:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x3A4);
-		case 0x00370005:
-			_read_float_value(0x3C0);
-		case 0x003F0000: // Van Gogh
-			_read_float_value(0x2C8); //652
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x3c4); //964
-	default:
-		break;
-	}
-	case 2:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x3A8);
-		case 0x00370005:
-			_read_float_value(0x3C4);
-		case 0x003F0000: // Van Gogh
-			_read_float_value(0x290); //656
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x3c8); //968
-	default:
-		break;
-	}
-	case 3:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x3AC);
-		case 0x00370005:
-			_read_float_value(0x3C8);
-		case 0x003F0000: // Van Gogh
-			_read_float_value(0x294); //660
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x3cc); //972
-	default:
-		break;
-	}
-	case 4:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x3B0);
-		case 0x00370005:
-			_read_float_value(0x3CC);
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x3d0); //976
-	default:
-		break;
-	}
-	case 5:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x3B4);
-		case 0x00370005:
-			_read_float_value(0x3D0);
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x3d4); //980
-	default:
-		break;
-	}
-	case 6:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x3B8);
-		case 0x00370005:
-			_read_float_value(0x3D4);
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x3d8); //984
-	default:
-		break;
-	}
-	case 7:
-		switch (ry->table_ver)
-		{
-		case 0x00370000:
-		case 0x00370001:
-		case 0x00370002:
-		case 0x00370003:
-		case 0x00370004:
-			_read_float_value(0x3BC);
-		case 0x00370005:
-			_read_float_value(0x3D8);
-		case 0x00400004:
-		case 0x00400005:
-			_read_float_value(0x3dc); //988
-	default:
-		break;
-	}
-	default:
-		break;
-	}
-	return NAN;
+
+	_read_float_value(baseOffset + (core *4));
 }
 
 EXP float CALL get_l3_clk(ryzen_access ry) {

--- a/lib/api.c
+++ b/lib/api.c
@@ -1385,7 +1385,6 @@ EXP int CALL set_cogfx(ryzen_access ry, uint32_t value) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_VANGOGH:
-	case FAM_STRIXHALO:	
 		_do_adjust_psmu(0xB7);
 		break;
 	case FAM_STRIXHALO:

--- a/lib/api.c
+++ b/lib/api.c
@@ -1050,6 +1050,8 @@ EXP int CALL set_apu_skin_temp_limit(ryzen_access ry, uint32_t value) {
 	case FAM_HAWKPOINT:
 		_do_adjust(0x33);
 		break;
+	case FAM_STRIXHALO:			
+		// not implemented on StrixHalo, seems to be controlled only via tctl-temp	
 	default:
 		break;
 	}
@@ -1075,9 +1077,10 @@ EXP int CALL set_dgpu_skin_temp_limit(ryzen_access ry, uint32_t value) {
 	case FAM_PHOENIX:
 	case FAM_HAWKPOINT:
 	case FAM_STRIXPOINT:
-	case FAM_STRIXHALO:
 		_do_adjust(0x34);
 		break;
+	case FAM_STRIXHALO:			
+		// not implemented on StrixHalo, seems to be controlled only via tctl-temp			
 	default:
 		break;
 	}
@@ -1424,6 +1427,7 @@ EXP float CALL get_apu_slow_limit(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x0064020c: // StrixHalo - looks correct from dumping table, defaults to 70W
 		_read_float_value(0x18);
 	default:
 		break;
@@ -1448,6 +1452,7 @@ EXP float CALL get_apu_slow_value(ryzen_access ry) {
 	case 0x00450004:
 	case 0x00450005:
 	case 0x004C0006:
+	case 0x0064020c: // StrixHalo - untested!	
 		_read_float_value(0x1C);
 	default:
 		break;
@@ -1728,7 +1733,7 @@ EXP float CALL get_tctl_temp(ryzen_access ry) {
 	case 0x001E0005:
 	case 0x001E000A:
 	case 0x001E0101:
-	case 0x0064020c:	
+	case 0x0064020c: // StrixHalo tested
 		_read_float_value(0x58); //use core1 because core0 is not reported on dual core cpus
 	case 0x00370000:
 	case 0x00370001:
@@ -1763,7 +1768,7 @@ EXP float CALL get_tctl_temp_value(ryzen_access ry) {
 	case 0x001E0005:
 	case 0x001E000A:
 	case 0x001E0101:
-	case 0x0064020c:
+	case 0x0064020c: // StrixHalo tested
 		_read_float_value(0x5C); //use core1 because core0 is not reported on dual core cpus
 	case 0x00370000:
 	case 0x00370001:
@@ -1808,8 +1813,9 @@ EXP float CALL get_apu_skin_temp_limit(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
-	case 0x0064020c:
+	case 0x0064020c: // StrixHalo tested	
 		_read_float_value(0x58);
+		break;	
 	default:
 		break;
 	}
@@ -1835,7 +1841,7 @@ EXP float CALL get_apu_skin_temp_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
-	case 0x0064020c:
+	case 0x0064020c: // StrixHalo tested
 		_read_float_value(0x5C);
 	default:
 		break;
@@ -1861,7 +1867,7 @@ EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
-	case 0x0064020c:	
+	case 0x0064020c: // StrixHalo tested
 		_read_float_value(0x60);
 	default:
 		break;

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -94,6 +94,8 @@ static enum ryzen_family cpuid_load_family()
         case 32:
         case 36:
             return FAM_STRIXPOINT;
+        case 112:
+            return FAM_STRIXHALO;
         default:
             printf("Fam%xh: unsupported model %d\n", family, model);
             break;

--- a/lib/nb_smu_ops.c
+++ b/lib/nb_smu_ops.c
@@ -85,6 +85,7 @@ smu_t get_smu(nb_t nb, int smu_type) {
 				smu->arg_base = MP1_C2PMSG_ARG_BASE_2;
 				break;
 			case FAM_STRIXPOINT:
+			case FAM_STRIXHALO:
 				smu->msg = MP1_C2PMSG_MESSAGE_ADDR_3;
 				smu->rep = MP1_C2PMSG_RESPONSE_ADDR_3;
 				smu->arg_base = MP1_C2PMSG_ARG_BASE_3;

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -27,6 +27,7 @@ enum ryzen_family {
         FAM_PHOENIX,
         FAM_HAWKPOINT,
         FAM_STRIXPOINT,
+        FAM_STRIXHALO,
         FAM_END
 };
 

--- a/main.c
+++ b/main.c
@@ -76,6 +76,7 @@ static const char *family_name(enum ryzen_family fam)
 	case FAM_PHOENIX: return "Phoenix Point";
 	case FAM_HAWKPOINT: return "Hawk Point";
 	case FAM_STRIXPOINT: return "Strix Point";
+	case FAM_STRIXHALO: return "Strix Halo";
 	default:
 		break;
 	}


### PR DESCRIPTION
Hi @FlyGoat,

It was good chatting with you via email.  I've made some progress on adding Strix Halo CPU support.   I'm attaching this PR but I'll keep adding to it in my workspace.  CPU undervolting works well (My machine can run reliablity down to about -40 0xfffd8 for coal  - if I go lower than that I start to see failures in the mprime stress test)

I think I'm pretty much done now.  THe only big missing feature is finding some way to make set-cogfx work, so the GPU can be undervolted also.

* Undervolting CPU with --set-coal seems to work
* Setting tctl-temp threshold for temperature based throttling (I highly recommend **not** raising the default of 95C, but lowering it might be useful for some)
* setting power limits stapm-limit, fast-limit, slow-limit
* Added support for reading per cor CPU power, voltage and temperature (16 cores)
* Basic dumping with -i or --dump-tables seems to work.

$ sudo ./ryzenadj -i
CPU Family: Strix Halo
SMU BIOS Interface Version: 25
Version: v0.16.0
PM Table Version: 64020c
|        Name         |   Value   |     Parameter      |
|---------------------|-----------|--------------------|
| STAPM LIMIT         |    71.000 | stapm-limit        |
| STAPM VALUE         |    20.293 |                    |
| PPT LIMIT FAST      |    71.000 | fast-limit         |
| PPT VALUE FAST      |    28.647 |                    |
| PPT LIMIT SLOW      |    52.000 | slow-limit         |
| PPT VALUE SLOW      |    22.021 |                    |
| StapmTimeConst      |       nan | stapm-time         |
| SlowPPTTimeConst    |       nan | slow-time          |
| PPT LIMIT APU       |       nan | apu-slow-limit     |
| PPT VALUE APU       |       nan |                    |
| TDC LIMIT VDD       |       nan | vrm-current        |
| TDC VALUE VDD       |       nan |                    |
| TDC LIMIT SOC       |       nan | vrmsoc-current     |
| TDC VALUE SOC       |       nan |                    |
| EDC LIMIT VDD       |       nan | vrmmax-current     |
| EDC VALUE VDD       |       nan |                    |
| EDC LIMIT SOC       |       nan | vrmsocmax-current  |
| EDC VALUE SOC       |       nan |                    |
| THM LIMIT CORE      |    95.000 | tctl-temp          |
| THM VALUE CORE      |    52.785 |                    |
| STT LIMIT APU       |    95.000 | apu-skin-temp      |
| STT VALUE APU       |    52.785 |                    |
| STT LIMIT dGPU      |    95.000 | dgpu-skin-temp     |
| STT VALUE dGPU      |    55.655 |                    |
| CCLK Boost SETPOINT |       nan | power-saving /     |
| CCLK BUSY VALUE     |       nan | max-performance    |