### PR TITLE
Add full support for ryzen_smu Linux kernel module, making `/dev/mem` and libpci optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+option(LINUX_USE_RYZEN_SMU_MODULE "Use ryzen_smu kernel module instead of /dev/mem" OFF)
 
 #Enable LTO
 include(CheckIPOSupported)
@@ -19,14 +20,15 @@ if( supported )
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
-INCLUDE_DIRECTORIES(${INC_DIR})
-
 AUX_SOURCE_DIRECTORY(./ SRC_DIR)
 
 if(WIN32)
 set(OS_SOURCE lib/osdep_win32.cpp)
 set(OS_LINK_LIBRARY WinRing0x64)
 set(OS_LINK_DIR ./win32)
+elseif(LINUX_USE_RYZEN_SMU_MODULE)
+add_compile_definitions(LINUX_USE_RYZEN_SMU_MODULE=1)
+set(OS_SOURCE lib/osdep_linux_smu_kernel_module.c)
 else()
 set(OS_SOURCE lib/osdep_linux.c)
 #if (CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/lib/api.c
+++ b/lib/api.c
@@ -390,7 +390,7 @@ EXP int CALL refresh_table(ryzen_access ry)
 		return errorcode;
 	}
 
-	if(copy_pm_table(ry->table_values, ry->table_size)){
+	if(copy_pm_table(ry->nb, ry->table_values, ry->table_size)){
 		printf("refresh_table failed\n");
 		return ADJ_ERR_MEMORY_ACCESS;
 	}

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -81,6 +81,11 @@ typedef struct _smu_service_args_t {
 typedef uint32_t *nb_t;
 typedef bool *pci_obj_t;
 typedef HINSTANCE *mem_obj_t;
+#elif defined LINUX_USE_RYZEN_SMU_MODULE
+typedef struct smu_kernel_module smu_kernel_module_t;
+typedef smu_kernel_module_t *pci_obj_t;
+typedef smu_kernel_module_t *nb_t;
+typedef void *mem_obj_t;
 #else
 #include <pci/pci.h>
 typedef struct pci_dev *nb_t;

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -117,7 +117,7 @@ mem_obj_t init_mem_obj(uintptr_t physAddr);
 
 void free_mem_obj(mem_obj_t obj);
 
-int copy_pm_table(void *buffer, size_t size);
+int copy_pm_table(nb_t nb, void *buffer, size_t size);
 
 int compare_pm_table(void *buffer, size_t size);
 

--- a/lib/osdep_linux.c
+++ b/lib/osdep_linux.c
@@ -99,8 +99,9 @@ void free_mem_obj(mem_obj_t obj)
 	return;
 }
 
-int copy_pm_table(void *buffer, size_t size)
+int copy_pm_table(nb_t nb, void *buffer, size_t size)
 {
+        (void)nb;
 	int read_size;
 
 	if(pm_table_fd > 0){

--- a/lib/osdep_linux.c
+++ b/lib/osdep_linux.c
@@ -6,11 +6,10 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
-#include <errno.h>
+
 #include "nb_smu_ops.h"
 
 bool mem_obj_obj = true;
-int pm_table_fd = 0;
 void *phy_map = MAP_FAILED;
 
 pci_obj_t init_pci_obj(){
@@ -51,38 +50,12 @@ void smn_reg_write(nb_t nb, u32 addr, u32 data)
 mem_obj_t init_mem_obj(uintptr_t physAddr)
 {
 	int dev_mem_fd; 
-	int dev_mem_errno, mmap_errno;
 
 	//It is to complicated to check PAT, CONFIG_NONPROMISC_DEVMEM, CONFIG_STRICT_DEVMEM or other dependencies, just try to open /dev/mem
 	dev_mem_fd = open("/dev/mem", O_RDONLY);
-	dev_mem_errno = errno;
 	if (dev_mem_fd > 0){
 		phy_map = mmap(NULL, 0x1000, PROT_READ, MAP_SHARED, dev_mem_fd, (long)physAddr);
-		mmap_errno = errno;
 		close(dev_mem_fd);
-	}
-
-	if(phy_map == MAP_FAILED){
-		//only complain about mmap errors if we don't have access to alternative smu driver
-		pm_table_fd = open("/sys/kernel/ryzen_smu_drv/pm_table", O_RDONLY);
-		if (pm_table_fd < 0) {
-			printf("failed to get /sys/kernel/ryzen_smu_drv/pm_table: %s\n", strerror(errno));
-
-			//show either fd error or mmap error, depending on which was the problem
-			if(dev_mem_errno) {
-				printf("failed to get /dev/mem: %s\n", strerror(dev_mem_errno));
-			} else {
-				printf("failed to map /dev/mem: %s\n", strerror(mmap_errno));
-			}
-
-			if(mmap_errno == EPERM || dev_mem_fd < 0) {
-				//we are already superuser if memory access is requested because we did successfully do the other smu calls.
-				//missing /dev/mem or missing permissions can only mean memory access policy
-				printf("If you don't want to change your memory access policy, you need a kernel module for this task.\n");
-				printf("We do support usage of this kernel module https://gitlab.com/leogx9r/ryzen_smu\n");
-			}
-			return NULL;
-		}
 	}
 
 	return &mem_obj_obj;
@@ -93,26 +66,12 @@ void free_mem_obj(mem_obj_t obj)
 	if(phy_map != MAP_FAILED){
 		munmap(phy_map, 0x1000);
 	}
-	if(pm_table_fd > 0) {
-		close(pm_table_fd);
-	}
 	return;
 }
 
 int copy_pm_table(nb_t nb, void *buffer, size_t size)
 {
-        (void)nb;
-	int read_size;
-
-	if(pm_table_fd > 0){
-		lseek(pm_table_fd, 0, SEEK_SET);
-		read_size = read(pm_table_fd, buffer, size);
-		if(read_size == -1) {
-			printf("failed to get pm_table from ryzen_smu kernel module: %s\n", strerror(errno));
-			return -1;
-		}
-		return 0;
-	}
+	(void)nb;
 
 	if(phy_map != MAP_FAILED){
 		memcpy(buffer, phy_map, size);
@@ -125,14 +84,10 @@ int copy_pm_table(nb_t nb, void *buffer, size_t size)
 
 int compare_pm_table(void *buffer, size_t size)
 {
-	if(pm_table_fd > 0){
-		//we can not compare to physial pm table location because we don't have direct memory access via SMU driver
-		return 0;
-	}
 	return memcmp(buffer, phy_map, size);
 }
 
 bool is_using_smu_driver()
 {
-	return pm_table_fd > 0;
+	return false;
 }

--- a/lib/osdep_linux_smu_kernel_module.c
+++ b/lib/osdep_linux_smu_kernel_module.c
@@ -1,0 +1,263 @@
+/* Backend which uses the sysfs interface provided by the ryzen_smu kernel module. */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+#include "nb_smu_ops.h"
+
+typedef struct
+{
+	FILE *file;
+	const char *static_file_path;
+} file_handle_t;
+
+struct smu_kernel_module {
+	file_handle_t smn;
+	file_handle_t pm_table;
+	size_t pm_table_size;
+};
+
+static bool path_exists(const char *file_path)
+{
+	const int old_errno = errno;
+	errno = 0;
+	struct stat stats;
+	const bool path_exists = lstat(file_path, &stats) == 0;
+	if(!path_exists && errno != 0 && errno != ENOENT)
+	{
+		fprintf(stderr, "failed to check existence of path: %s\n", file_path);
+	}
+	errno = old_errno;
+	return path_exists;
+}
+
+static file_handle_t open_file(const char *static_file_path, const char *mode)
+{
+	file_handle_t result = {
+		.file = fopen(static_file_path, mode),
+		.static_file_path = static_file_path
+	};
+	if(result.file == NULL)
+	{
+		fprintf(stderr, "failed to open file: '%s': %s\n",
+			static_file_path, strerror(errno));
+	}
+	return result;
+}
+
+static bool close_file(file_handle_t file)
+{
+	if(fclose(file.file) != 0)
+	{
+		fprintf(stderr, "failed to close file: '%s': %s\n",
+			file.static_file_path, strerror(errno));
+		return false;
+	}
+	return true;
+}
+
+static bool read_from_start_up_to_bytes(file_handle_t input, void *out,
+					const size_t out_size,
+					size_t *out_bytes_read)
+{
+	fseek(input.file, 0, SEEK_SET);
+	const size_t bytes_read = fread(out, 1, out_size, input.file);
+	if(ferror(input.file))
+	{
+		fprintf(stderr, "failed to read from file: '%s': %s\n",
+			input.static_file_path, strerror(errno));
+		return false;
+	}
+	*out_bytes_read = bytes_read;
+	return true;
+}
+
+static bool read_from_start(file_handle_t input, void *out, const size_t out_size)
+{
+	size_t bytes_read = 0;
+	if(!read_from_start_up_to_bytes(input, out, out_size, &bytes_read))
+	{
+		return false;
+	}
+	if(bytes_read != out_size)
+	{
+		fprintf(stderr, "failed to read complete data from file: '%s'\n",
+			input.static_file_path);
+		return false;
+	}
+	return true;
+}
+
+static bool write_to_start(file_handle_t output, const void *data, const size_t data_size)
+{
+	fseek(output.file, 0, SEEK_SET);
+	const size_t bytes_written = fwrite(data, 1, data_size, output.file);
+	if(ferror(output.file))
+	{
+		fprintf(stderr, "failed to write to file: '%s': %s\n",
+			output.static_file_path, strerror(errno));
+		return false;
+	}
+	if(bytes_written != data_size)
+	{
+		fprintf(stderr, "failed to write complete data to file: '%s'\n",
+			output.static_file_path);
+		return false;
+	}
+	return true;
+}
+
+static bool driver_compatible(void)
+{
+	file_handle_t input = open_file("/sys/kernel/ryzen_smu_drv/drv_version", "rb");
+	if(input.file == NULL)
+	{
+		return false;
+	}
+
+	size_t bytes_read = 0;
+	char version[32] = {0};
+	const bool success =
+		read_from_start_up_to_bytes(input, version, sizeof(version), &bytes_read);
+	(void)close_file(input);
+	if(!success)
+	{
+		return false;
+	}
+
+	version[bytes_read] = '\0';
+	if(strstr(version, "0.") != version)
+	{
+		fprintf(stderr, "incompatible ryzen_smu module major version: %s\n", version);
+		return false;
+	}
+	return true;
+}
+
+static bool read_pm_table_size(u32 *out)
+{
+	file_handle_t input = open_file("/sys/kernel/ryzen_smu_drv/pm_table_size", "rb");
+	if(input.file == NULL)
+	{
+		return false;
+	}
+	const bool success = read_from_start(input, out, sizeof(*out));
+	(void)close_file(input);
+	return success;
+}
+
+pci_obj_t init_pci_obj(void)
+{
+	if(!path_exists("/sys/kernel/ryzen_smu_drv"))
+	{
+		return NULL;
+	}
+	printf("detected ryzen_smu kernel module, initializing...\n");
+
+	if(!driver_compatible())
+	{
+		return NULL;
+	}
+
+	u32 pm_table_size = 0;
+	if(!read_pm_table_size(&pm_table_size))
+	{
+		fprintf(stderr, "failed to retrieve PM table size from ryzen_smu kernel module\n");
+		return NULL;
+	}
+
+	smu_kernel_module_t *result = malloc(sizeof *result);
+	if(result == NULL)
+	{
+		return NULL;
+	}
+	result->smn = open_file("/sys/kernel/ryzen_smu_drv/smn", "r+b");
+	if(result->smn.file == NULL)
+	{
+		free(result);
+		return NULL;
+	}
+	result->pm_table = open_file("/sys/kernel/ryzen_smu_drv/pm_table", "rb");
+	if(result->pm_table.file == NULL)
+	{
+		(void)close_file(result->smn);
+		free(result);
+		return NULL;
+	}
+	result->pm_table_size = pm_table_size;
+	return result;
+}
+
+void free_pci_obj(pci_obj_t obj)
+{
+	(void)close_file(obj->pm_table);
+	(void)close_file(obj->smn);
+	free(obj);
+}
+
+nb_t get_nb(pci_obj_t obj)
+{
+	return obj;
+}
+
+void free_nb(nb_t nb)
+{
+	(void)nb;
+}
+
+mem_obj_t init_mem_obj(const uintptr_t physAddr)
+{
+	(void)physAddr;
+	return (mem_obj_t)0xDEADC0DE; /* Mem_obj is not needed in this backend. */
+}
+
+void free_mem_obj(mem_obj_t obj)
+{
+	(void)obj;
+}
+
+u32 smn_reg_read(nb_t nb, const u32 addr)
+{
+	u32 result = 0;
+	if(!write_to_start(nb->smn, &addr, sizeof(addr)) ||
+	   !read_from_start(nb->smn, &result, sizeof(result)))
+	{
+		return 0;
+	}
+	return result;
+}
+
+void smn_reg_write(nb_t nb, const u32 addr, const u32 data)
+{
+	const u32 write_buffer[2] = { addr, data };
+	write_to_start(nb->smn, &write_buffer, sizeof(write_buffer));
+}
+
+int copy_pm_table(nb_t nb, void *buffer, const size_t size)
+{
+	if(nb->pm_table_size != size)
+	{
+		fprintf(stderr, "PM table size mismatch between ryzenadj and ryzen_smu kernel module\n");
+		return -1;
+	}
+	if(!read_from_start(nb->pm_table, buffer, size))
+	{
+		return -1;
+	}
+	return 0;
+}
+
+int compare_pm_table(void *buffer, const size_t size)
+{
+	(void)buffer;
+	(void)size;
+	printf("internal error: compare_pm_table() should never be called if smu driver is available\n");
+	return -1;
+}
+
+bool is_using_smu_driver(void)
+{
+	return true;
+}

--- a/lib/osdep_win32.cpp
+++ b/lib/osdep_win32.cpp
@@ -118,8 +118,9 @@ extern "C" void free_mem_obj(mem_obj_t hInpOutDll)
     FreeLibrary((HINSTANCE)hInpOutDll);
 }
 
-extern "C" int copy_pm_table(void *buffer, size_t size)
+extern "C" int copy_pm_table(nb_t nb, void *buffer, size_t size)
 {
+    (void)nb;
     memcpy(buffer, pdwLinAddr, size);
     return 0;
 }


### PR DESCRIPTION
RyzenAdj has partial support for the ryzen_smu kernel module, but uses it only for optional retrieval of the PM table. With this merge request I'm adding a new CMake feature flag, which allows using RyzenAdj on Linux **without** exposing `/dev/mem` and **without** needing libpci.

Closes #231