### PR TITLE
Update support for AMD Ryzen 7840U

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -176,6 +176,7 @@ static int request_table_ver_and_size(ryzen_access ry)
 	case 0x450004: ry->table_size = 0xA44; break;
 	case 0x450005: ry->table_size = 0xA44; break;
 	case 0x4C0006: ry->table_size = 0xAA0; break;
+	case 0x4C0009: ry->table_size = 0xAA0; break;
 	case 0x64020c: ry->table_size = 0xE50; break;
 		default:
 			//use a larger size then the largest known table to be able to test real table size of unknown tables
@@ -1427,6 +1428,7 @@ EXP float CALL get_apu_slow_limit(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 	case 0x0064020c: // StrixHalo - looks correct from dumping table, defaults to 70W
 		_read_float_value(0x18);
 	default:
@@ -1452,6 +1454,7 @@ EXP float CALL get_apu_slow_value(ryzen_access ry) {
 	case 0x00450004:
 	case 0x00450005:
 	case 0x004C0006:
+	case 0x004C0009:
 	case 0x0064020c: // StrixHalo - untested!	
 		_read_float_value(0x1C);
 	default:
@@ -1486,6 +1489,7 @@ EXP float CALL get_vrm_current(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x20);
 	default:
 		break;
@@ -1519,6 +1523,7 @@ EXP float CALL get_vrm_current_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x24);
 	default:
 		break;
@@ -1552,6 +1557,7 @@ EXP float CALL get_vrmsoc_current(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x28);
 	default:
 		break;
@@ -1585,6 +1591,7 @@ EXP float CALL get_vrmsoc_current_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x2C);
 	default:
 		break;
@@ -1618,6 +1625,7 @@ EXP float CALL get_vrmmax_current(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x30);
 	default:
 		break;
@@ -1651,6 +1659,7 @@ EXP float CALL get_vrmmax_current_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x34);
 	default:
 		break;
@@ -1684,6 +1693,7 @@ EXP float CALL get_vrmsocmax_current(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x38);
 	default:
 		break;
@@ -1717,6 +1727,7 @@ EXP float CALL get_vrmsocmax_current_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x3C);
 	default:
 		break;
@@ -1752,6 +1763,7 @@ EXP float CALL get_tctl_temp(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x40);
 	default:
 		break;
@@ -1787,6 +1799,7 @@ EXP float CALL get_tctl_temp_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x44);
 	default:
 		break;
@@ -1813,6 +1826,7 @@ EXP float CALL get_apu_skin_temp_limit(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 	case 0x0064020c: // StrixHalo tested	
 		_read_float_value(0x58);
 		break;	
@@ -1841,6 +1855,7 @@ EXP float CALL get_apu_skin_temp_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 	case 0x0064020c: // StrixHalo tested
 		_read_float_value(0x5C);
 	default:
@@ -1867,6 +1882,7 @@ EXP float CALL get_dgpu_skin_temp_limit(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 	case 0x0064020c: // StrixHalo tested
 		_read_float_value(0x60);
 	default:
@@ -1893,6 +1909,7 @@ EXP float CALL get_dgpu_skin_temp_value(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 	case 0x0064020c:	
 		_read_float_value(0x64);
 	default:
@@ -1926,6 +1943,7 @@ EXP float CALL get_psi0_current(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x78);
 	default:
 		break;
@@ -1958,6 +1976,7 @@ EXP float CALL get_psi0soc_current(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x80);
 	default:
 		break;
@@ -2060,6 +2079,7 @@ EXP float CALL get_stapm_time(ryzen_access ry)
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x918);
 	default:
 		break;
@@ -2101,6 +2121,7 @@ EXP float CALL get_slow_time(ryzen_access ry) {
 	case 0x004C0006:
 	case 0x004C0007:
 	case 0x004C0008:
+	case 0x004C0009:
 		_read_float_value(0x91C);
 	default:
 		break;


### PR DESCRIPTION
My Phoenix CPU's table version switched from `0x004C0008` to `0x004C0009`. I don't know why, but here is the system I've tested with:

Framework Laptop 13
Ryzen 7840U
ryzen_smu Linux module (see #341)