### PR TITLE
Add basic Dragon Range and Fire Range support

### DIFF
--- a/lib/api.c
+++ b/lib/api.c
@@ -455,6 +455,9 @@ EXP int CALL set_stapm_limit(ryzen_access ry, uint32_t value){
             printf("%s: Retry with PSMU\n", __func__);
 		    _do_adjust_psmu(0x31);
         }
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust(0x4f);
 	default:
 		break;
 	}
@@ -484,6 +487,9 @@ EXP int CALL set_fast_limit(ryzen_access ry, uint32_t value){
 	case FAM_STRIXPOINT:
 	case FAM_STRIXHALO:
 		_do_adjust(0x15);
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust(0x3e);
 	default:
 		break;
 	}
@@ -514,6 +520,9 @@ EXP int CALL set_slow_limit(ryzen_access ry, uint32_t value){
 	case FAM_STRIXPOINT:
 	case FAM_STRIXHALO:
 		_do_adjust(0x16);
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust(0x5f);
 	default:
 		break;
 	}
@@ -544,6 +553,9 @@ EXP int CALL set_slow_time(ryzen_access ry, uint32_t value){
 	case FAM_STRIXPOINT:
 	case FAM_STRIXHALO:
 		_do_adjust(0x17);
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust(0x60);
 	default:
 		break;
 	}
@@ -574,6 +586,9 @@ EXP int CALL set_stapm_time(ryzen_access ry, uint32_t value){
 	case FAM_STRIXPOINT:
 	case FAM_STRIXHALO:
 		_do_adjust(0x18);
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust(0x4e);
 	default:
 		break;
 	}
@@ -604,6 +619,9 @@ EXP int CALL set_tctl_temp(ryzen_access ry, uint32_t value){
 	case FAM_STRIXPOINT:
 	case FAM_STRIXHALO:
 		_do_adjust(0x19);
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust(0x3f);
 	default:
 		break;
 	}
@@ -634,6 +652,9 @@ EXP int CALL set_vrm_current(ryzen_access ry, uint32_t value){
 	case FAM_STRIXPOINT:
 	case FAM_STRIXHALO:
 		_do_adjust(0x1a);
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust(0x3c);
 	default:
 		break;
 	}
@@ -1356,6 +1377,10 @@ EXP int CALL set_coall(ryzen_access ry, uint32_t value) {
 	case FAM_STRIXHALO:
 		_do_adjust(0x4C);
 		break;
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust_psmu(0x7);
+		break;
 	default:
 		break;
 	}
@@ -1380,6 +1405,10 @@ EXP int CALL set_coper(ryzen_access ry, uint32_t value) {
 	case FAM_STRIXPOINT:
 	case FAM_STRIXHALO:
 		_do_adjust(0x4b);
+		break;
+	case FAM_DRAGONRANGE:
+	case FAM_FIRERANGE:
+		_do_adjust_psmu(0x6);
 		break;
 	default:
 		break;

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -79,6 +79,8 @@ static enum ryzen_family cpuid_load_family()
         case 64:
         case 68:
             return FAM_REMBRANDT;
+        case 97:
+            return FAM_DRAGONRANGE;
         case 116:
         case 120:
             return FAM_PHOENIX;
@@ -94,6 +96,8 @@ static enum ryzen_family cpuid_load_family()
         case 32:
         case 36:
             return FAM_STRIXPOINT;
+        case 68:
+            return FAM_FIRERANGE;
         case 96:
             return FAM_KRACKANPOINT;
         case 112:

--- a/lib/nb_smu_ops.c
+++ b/lib/nb_smu_ops.c
@@ -19,9 +19,18 @@
 #define MP1_C2PMSG_RESPONSE_ADDR_3	0x3b10978
 #define MP1_C2PMSG_ARG_BASE_3		0x3b10998
 
-#define PSMU_C2PMSG_MESSAGE_ADDR          0x3B10a20
-#define PSMU_C2PMSG_RESPONSE_ADDR         0x3B10a80
-#define PSMU_C2PMSG_ARG_BASE              0x3B10a88
+#define PSMU_C2PMSG_MESSAGE_ADDR_1          0x3B10a20
+#define PSMU_C2PMSG_RESPONSE_ADDR_1         0x3B10a80
+#define PSMU_C2PMSG_ARG_BASE_1              0x3B10a88
+
+/* For Dragon and Fire Range */
+#define MP1_C2PMSG_MESSAGE_ADDR_4	0x3B10530
+#define MP1_C2PMSG_RESPONSE_ADDR_4	0x3B1057C
+#define MP1_C2PMSG_ARG_BASE_4		0x3B109C4
+
+#define PSMU_C2PMSG_MESSAGE_ADDR_2          0x03B10524
+#define PSMU_C2PMSG_RESPONSE_ADDR_2         0x03B10570
+#define PSMU_C2PMSG_ARG_BASE_2              0x03B10A40
 
 /*
 * All the SMU have the same TestMessage as for now
@@ -119,6 +128,12 @@ smu_t get_smu(os_access_obj_t *obj, const int smu_type) {
 				smu->rep = MP1_C2PMSG_RESPONSE_ADDR_3;
 				smu->arg_base = MP1_C2PMSG_ARG_BASE_3;
 				break;
+			case FAM_DRAGONRANGE:
+			case FAM_FIRERANGE:
+				smu->msg = MP1_C2PMSG_MESSAGE_ADDR_4;
+				smu->rep = MP1_C2PMSG_RESPONSE_ADDR_4;
+				smu->arg_base = MP1_C2PMSG_ARG_BASE_4;
+				break;
 			default:
 				smu->msg = MP1_C2PMSG_MESSAGE_ADDR_1;
 				smu->rep = MP1_C2PMSG_RESPONSE_ADDR_1;
@@ -127,10 +142,19 @@ smu_t get_smu(os_access_obj_t *obj, const int smu_type) {
 			}
 			break;
 		case TYPE_PSMU:
-			smu->msg = PSMU_C2PMSG_MESSAGE_ADDR;
-			smu->rep = PSMU_C2PMSG_RESPONSE_ADDR;
-			smu->arg_base = PSMU_C2PMSG_ARG_BASE;
-			break;
+			switch (cpuid_get_family()) {
+			case FAM_DRAGONRANGE:
+			case FAM_FIRERANGE:
+				smu->msg = PSMU_C2PMSG_MESSAGE_ADDR_2;
+				smu->rep = PSMU_C2PMSG_RESPONSE_ADDR_2;
+				smu->arg_base = PSMU_C2PMSG_ARG_BASE_2;
+				break;
+			default:
+				smu->msg = PSMU_C2PMSG_MESSAGE_ADDR_1;
+				smu->rep = PSMU_C2PMSG_RESPONSE_ADDR_1;
+				smu->arg_base = PSMU_C2PMSG_ARG_BASE_1;
+				break;
+			}
 		default:
 			DBG("Failed to get SMU, unknown SMU_TYPE: %i\n", smu_type);
 			goto err;

--- a/lib/ryzenadj.h
+++ b/lib/ryzenadj.h
@@ -26,9 +26,11 @@ enum ryzen_family {
         FAM_MENDOCINO,
         FAM_PHOENIX,
         FAM_HAWKPOINT,
+        FAM_DRAGONRANGE,
         FAM_KRACKANPOINT,
         FAM_STRIXPOINT,
         FAM_STRIXHALO,
+        FAM_FIRERANGE,
         FAM_END
 };
 


### PR DESCRIPTION
Adds basic support for those with 7040HX, 7045HX, 8045HX, 9050HX, and 9055HX mobile CPUs.

This includes the following features:
- STAMP, Fast/Slow PPT limit and duration control
- Tctl limit control
- VRM current control
- Curve Optimiser offset support 