### PR TITLE
Fix spelling mistakes across documentation, CLI, and Windows tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ these two methods:
 * Using libpci and exposing `/dev/mem`
 * Using the ryzen\_smu kernel module
 
-RyzenAdj will try ryzen\_smu first, and then fallback to /dev/mem, if no compatible smu driver is found.  
-The minimum supported version of ryzen_smu is 0.1.7  
-If no backend is available, RyzenAdj will fail initialization.  
+RyzenAdj will try ryzen\_smu first, and then fallback to /dev/mem, if no compatible smu driver is found.
+The minimum supported version of ryzen_smu is 0.1.7
+If no backend is available, RyzenAdj will fail initialization.
 
 _**Please note that `/dev/mem` access may be restricted, for security reasons, in your kernel config**_
 
@@ -139,7 +139,7 @@ On OpenSUSE Tumbleweed:
 
     sudo zypper in cmake gcc14-c++ pciutils-devel
 
-You may need to add the `iomem=relaxed` param to your kernel params on Tumbleweed, or [you may run into errors at runtime](https://github.com/FlyGoat/RyzenAdj/issues/241). 
+You may need to add the `iomem=relaxed` param to your kernel params on Tumbleweed, or [you may run into errors at runtime](https://github.com/FlyGoat/RyzenAdj/issues/241).
 
 If your Distribution is not supported, try finding the packages or use [Distrobox](https://github.com/89luca89/distrobox) or [Toolbox](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/) instead.
 
@@ -200,11 +200,11 @@ sudo cp -v build/ryzenadj /usr/local/bin/
 
 ### Windows
 
-It can be built by Visual Studio + MSVC automaticaly, or Clang + Nmake in command line.
+It can be built by Visual Studio + MSVC automatically, or Clang + Nmake in command line.
 However, as for now, MingW-gcc can't be used to compile for some reason.
 
 Required dll is included in ./win32 of source tree. Please put the dll
 library and sys driver in the same folder with ryzenadj.exe.
 
-We don't recommend you to build by yourself on Windows since the environment configuarion
+We don't recommend you to build by yourself on Windows since the environment configuration
 is very complicated. If you would like to use ryzenadj functions in your program, see libryzenadj.

--- a/lib/nb_smu_ops.c
+++ b/lib/nb_smu_ops.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL
 /* Copyright (C) 2018-2019 Jiaxun Yang <jiaxun.yang@flygoat.com> */
-/* Ryzen NB SMU Service Request Opreations */
+/* Ryzen NB SMU Service Request Operations */
 #include <stdlib.h>
 
 #include "ryzenadj.h"
@@ -59,7 +59,7 @@ uint32_t smu_service_req(smu_t smu, const uint32_t id, smu_service_args_t *args)
 	smn_reg_write(smu->os_access, c2pmsg_argX_addr(smu->arg_base, 5), args->arg5);
 	/* Send message ID */
 	smn_reg_write(smu->os_access, smu->msg, id);
-	/* Wait until reponse changed */
+	/* Wait until response changed */
 	while(response == 0x0) {
 		response = smn_reg_read(smu->os_access, smu->rep);
 	}
@@ -92,7 +92,7 @@ static int smu_service_test(smu_t smu)
 
 	/* Send message ID */
 	smn_reg_write(smu->os_access, smu->msg, SMU_TEST_MSG);
-	/* Wait until reponse changed */
+	/* Wait until response changed */
 	while(response == 0x0) {
 		response = smn_reg_read(smu->os_access, smu->rep);
 	}
@@ -165,7 +165,7 @@ smu_t get_smu(os_access_obj_t *obj, const int smu_type) {
 	if(smu_service_test(smu)){
 		return smu;
 	} else {
-		DBG("Faild to get SMU, SMU_TYPE: %i\n", smu_type);
+		DBG("Failed to get SMU, SMU_TYPE: %i\n", smu_type);
 		goto err;
 	}
 err:

--- a/lib/nb_smu_ops.h
+++ b/lib/nb_smu_ops.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: LGPL */
 /* Copyright (C) 2018-2019 Jiaxun Yang <jiaxun.yang@flygoat.com> */
-/* Ryzen NB SMU Service Request Opreations */
+/* Ryzen NB SMU Service Request Operations */
 
 #pragma once
 

--- a/lib/win32/OlsDef.h
+++ b/lib/win32/OlsDef.h
@@ -34,7 +34,7 @@
 #define OLS_DRIVER_TYPE_WIN_NT			2
 #define OLS_DRIVER_TYPE_WIN_NT4			3	// Obsolete
 #define OLS_DRIVER_TYPE_WIN_NT_X64		4
-#define OLS_DRIVER_TYPE_WIN_NT_IA64		5	// Reseved
+#define OLS_DRIVER_TYPE_WIN_NT_IA64		5	// Reserved
 
 //-----------------------------------------------------------------------------
 //

--- a/lib/win32/osdep_win32.cpp
+++ b/lib/win32/osdep_win32.cpp
@@ -40,7 +40,7 @@ os_access_obj_t *init_os_access_obj() {
             return obj;
         }
         case OLS_DLL_UNSUPPORTED_PLATFORM:
-            DBG("WinRing0 Err: Unsupported Plattform\n");
+            DBG("WinRing0 Err: Unsupported Platform\n");
             break;
         case OLS_DLL_DRIVER_NOT_LOADED:
             DBG("WinRing0 Err: Driver not loaded\n");

--- a/main.c
+++ b/main.c
@@ -18,7 +18,7 @@ do {                                                                            
 		int adjerr = set_##ARG(ry, ARG);                                          \
 		if (!adjerr){                                                             \
 			any_adjust_applied = 1;                                               \
-			printf("Sucessfully set " STRINGIFY(ARG) " to %u\n", ARG);            \
+			printf("Successfully set " STRINGIFY(ARG) " to %u\n", ARG);            \
 		} else if (adjerr == ADJ_ERR_FAM_UNSUPPORTED) {                           \
 			printf("set_" STRINGIFY(ARG) " is not supported on this family\n");   \
 			err = -1;                                                             \
@@ -41,7 +41,7 @@ do {                                                                            
 		int adjerr = set_##ARG(ry);                                               \
 		if (!adjerr){                                                             \
 			any_adjust_applied = 1;                                               \
-			printf("Sucessfully enable " STRINGIFY(ARG) "\n");                    \
+			printf("Successfully enable " STRINGIFY(ARG) "\n");                    \
 		} else if (adjerr == ADJ_ERR_FAM_UNSUPPORTED) {                           \
 			printf("set_" STRINGIFY(ARG) " is not supported on this family\n");   \
 			err = -1;                                                             \
@@ -205,7 +205,7 @@ int main(int argc, const char **argv)
 	uint32_t skin_temp_power_limit = -1;
 	uint32_t gfx_clk = -1, oc_clk = -1, oc_volt = -1, coall = -1, coper = -1, cogfx = -1;
 
-	//create structure for parseing
+	//create structure for parsing
 	struct argparse_option options[] = {
 		OPT_HELP(),
 		OPT_GROUP("Options"),
@@ -246,7 +246,7 @@ int main(int argc, const char **argv)
 		OPT_U32('\0', "skin-temp-limit", &skin_temp_power_limit, "Skin Temperature Power Limit (mW)"),
 		OPT_U32('\0', "gfx-clk", &gfx_clk, "Forced Clock Speed MHz (Renoir Only)"),
 		OPT_U32('\0', "oc-clk", &oc_clk, "Forced Core Clock Speed MHz (Renoir and up Only)"),
-		OPT_U32('\0', "oc-volt", &oc_volt, "Forced Core VID: Must follow this calcuation (1.55 - [VID you want to set e.g. 1.25 for 1.25v]) / 0.00625 (Renoir and up Only)"),
+		OPT_U32('\0', "oc-volt", &oc_volt, "Forced Core VID: Must follow this calculation (1.55 - [VID you want to set e.g. 1.25 for 1.25v]) / 0.00625 (Renoir and up Only)"),
 		OPT_BOOLEAN('\0', "enable-oc", &enable_oc, "Enable OC (Renoir and up Only)"),
 		OPT_BOOLEAN('\0', "disable-oc", &disable_oc, "Disable OC (Renoir and up Only)"),
 		OPT_U32('\0', "set-coall", &coall, "All core Curve Optimiser"),

--- a/win32/installServiceTask.bat
+++ b/win32/installServiceTask.bat
@@ -6,7 +6,7 @@ if %errorlevel% NEQ 0 (
 	exit /B 0
 )
 
-cd /D "%~dp0" 
+cd /D "%~dp0"
 choice /C YN /M "Do you want to install Service based on directory %~dp0? It can not be changed after installation."
 if %ERRORLEVEL% NEQ 1 exit /B 1
 
@@ -14,7 +14,7 @@ for %%f in (RyzenAdjServiceTask.xml.template readjustService.ps1 libryzenadj.dll
    if not exist %%f echo %%f is missing && goto failed
 )
 
-echo Please configure RyzenAdjService by adding your prefered values in the top section of the powershell script. 
+echo Please configure RyzenAdjService by adding your preferred values in the top section of the powershell script.
 timeout /t 2 > NUL
 notepad "%~dp0\readjustService.ps1"
 
@@ -29,7 +29,7 @@ timeout /t 2 > NUL
 SCHTASKS /query /TN "AMD\RyzenAdj" || goto failed
 
 echo.
-echo Installation successfull
+echo Installation successful
 pause
 exit /B 0
 

--- a/win32/readjustService.ps1
+++ b/win32/readjustService.ps1
@@ -16,7 +16,7 @@ $Error.Clear()
 ################################################################################
 # WARNING: Use at your own risk!
 
-$pathToRyzenAdjDlls = Split-Path -Parent $PSCommandPath #script path is DLL path, needs to be absolut path if you define something else
+$pathToRyzenAdjDlls = Split-Path -Parent $PSCommandPath #script path is DLL path, needs to be absolute path if you define something else
 
 $showErrorPopupsDuringInit = $true
 # debug mode prints adjust success messages too instead of errorss only
@@ -30,7 +30,7 @@ $monitorPowerSlider = $true
 $monitorACLineStatus = $true
 # HWiNFO needs to be restartet after this script did run the first time with this option
 $updateHWINFOSensors = $false
-# some Zen3 devices have a locked STAPM limit, this workarround resets the stapm timer to have unlimited stapm. Use max stapm_limit and stapm_time (usually 500) to triger as less resets as possible
+# some Zen3 devices have a locked STAPM limit, this workaround resets the stapm timer to have unlimited stapm. Use max stapm_limit and stapm_time (usually 500) to trigger as less resets as possible
 $resetSTAPMUsage = $false
 
 function doAdjust_ACmode {
@@ -44,13 +44,13 @@ function doAdjust_ACmode {
     #replace any_other_field with additional adjustments. Name is equal to RyzenAdj options but it uses _ instead of -
     #adjust "any_other_field" 1234
 
-    #custom code, for example set fan controll back to auto
+    #custom code, for example set fan control back to auto
     #values (WriteRegister: 47, FanSpeedResetValue:128) extracted from similar devices at https://github.com/hirschmann/nbfc/blob/master/Configs/
     #Start-Process -NoNewWindow -Wait -filePath "C:\Program Files (x86)\NoteBook FanControl\ec-probe.exe" -ArgumentList("write", "47", "128")
 
     if($Script:acSlider -eq $Script:betterBattery){
         #put adjustments for energie saving slider position here:
-        enable "power_saving" #add 10s boost delay for usage on cable to reduce idle power consumtion
+        enable "power_saving" #add 10s boost delay for usage on cable to reduce idle power consumption
     }
 }
 
@@ -235,7 +235,7 @@ function enable ([String] $fieldName) {
 function testMonitorField {
     if($monitorField -and $Script:monitorFieldAdjTarget -eq 0){
         Write-Error ("You forgot to set $monitorField in your profile.$NL$NL" +
-            "If you ignore it, the script will apply values unnessasary often.$NL")
+            "If you ignore it, the script will apply values unnecessary often.$NL")
     }
 }
 
@@ -364,7 +364,7 @@ function updateHWINFOSensors {
 function resetSTAPMIfNeeded {
     $stapm_limit = [ryzen.adj]::get_stapm_limit($ry)
     $stapm_value = [ryzen.adj]::get_stapm_value($ry)
-    $stapm_hysteresis = 1 #Throttling starts arround ~0.9W before limit
+    $stapm_hysteresis = 1 #Throttling starts around ~0.9W before limit
 
     if ($stapm_value -gt ($stapm_limit - $stapm_hysteresis)) {
         $stapm_time = [ryzen.adj]::get_stapm_time($ry)


### PR DESCRIPTION
Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-11-29T18:06:46Z
Repository: RyzenAdj
Branch: master
Signing: GPG (989AF9F0)
Performance: 8 files, +26/-26 lines


Summary:

Fixed README Windows build section typos (“automatically”, “configuration”) for clarity @README.md#203-210.

Corrected console messages and option descriptions in main CLI (e.g., “Successfully”, “parsing”, “calculation”) @main.c#18-255.

Updated SMU operation sources to use proper spelling in comments and logs @lib/nb_smu_ops.c#3-168 @lib/nb_smu_ops.h#1-4.

Standardized Windows-specific headers for “Reserved” wording @lib/win32/OlsDef.h#32-38 and “Platform” pragma message @lib/win32/osdep_win32.cpp#39-45.

Refined installer batch script messaging (“preferred”, “successful”) @win32/installServiceTask.bat#17-33.

Cleaned PowerShell service script typos (e.g., “absolute”, “workaround”, “trigger”, “control”, “consumption”, “unnecessary”, “around”) to improve readability @win32/readjustService.ps1#19-368.