### PR TITLE
fix: PM table size mismatch on Raven/Picasso with ryzen_smu

### DIFF
--- a/lib/linux/osdep_linux_smu_kernel_module.c
+++ b/lib/linux/osdep_linux_smu_kernel_module.c
@@ -96,9 +96,13 @@ void smn_reg_write_kmod(const os_access_obj_t *obj, const uint32_t addr, const u
 }
 
 int copy_pm_table_kmod(const os_access_obj_t *obj, void *buffer, const size_t size) {
-	if (obj->access.kmod.pm_table_size != size) {
-		DBG("PM table size mismatch: ryzenadj (%zd) | ryzen_smu (%zd)\n", size, obj->access.kmod.pm_table_size);
+	if (obj->access.kmod.pm_table_size < size) {
+		DBG("PM table size too small: ryzenadj (%zd) | ryzen_smu (%zd)\n", size, obj->access.kmod.pm_table_size);
 		return -1;
+	}
+
+	if (obj->access.kmod.pm_table_size != size) {
+		DBG("PM table size mismatch (reading prefix): ryzenadj (%zd) | ryzen_smu (%zd)\n", size, obj->access.kmod.pm_table_size);
 	}
 
 	lseek(obj->access.kmod.pm_table_fd, 0, SEEK_SET);


### PR DESCRIPTION
The ryzen_smu kernel module concatenates primary and secondary PM tables
for Raven, Raven Ridge 2, and Picasso (0x608 + 0xA4 = 0x6AC), but ryzenadj
expects exactly 0x608 for these table versions. The strict equality check in
`copy_pm_table_kmod()` fails with `refresh_table failed` / `-5`.

The `/dev/mem` path doesn't have this issue — it maps a full page and reads
only the requested size. This patch aligns the kmod path to the same behavior:
fail if the driver table is smaller than expected, read the prefix otherwise.

Tested on Raven Ridge (Ryzen 5 2500U, PM table version 0x1E0004):

```
$ sudo ryzenadj --info
detected compatible ryzen_smu kernel module
CPU Family: Raven
SMU BIOS Interface Version: 6
Version: v0.17.0
PM Table Version: 1e0004
|        Name         |   Value   |     Parameter      |
|---------------------|-----------|--------------------|
| STAPM LIMIT         |    22.000 | stapm-limit        |
| STAPM VALUE         |     3.530 |                    |
| PPT LIMIT FAST      |    25.000 | fast-limit         |
| PPT VALUE FAST      |     3.490 |                    |
| PPT LIMIT SLOW      |    25.000 | slow-limit         |
| PPT VALUE SLOW      |     3.491 |                    |
| TDC LIMIT VDD       |    35.000 | vrm-current        |
| TDC VALUE VDD       |     1.020 |                    |
| TDC LIMIT SOC       |    10.000 | vrmsoc-current     |
| TDC VALUE SOC       |     0.632 |                    |
| EDC LIMIT VDD       |    45.000 | vrmmax-current     |
| EDC VALUE VDD       |    28.597 |                    |
| EDC LIMIT SOC       |    13.000 | vrmsocmax-current  |
| EDC VALUE SOC       |     2.024 |                    |
| THM LIMIT CORE      |    85.000 | tctl-temp          |
| THM VALUE CORE      |    37.628 |                    |
```

Fixes #397